### PR TITLE
Feature/bugfix threadsafe 20150129

### DIFF
--- a/fst.go
+++ b/fst.go
@@ -42,7 +42,7 @@ func (ps PairSlice) maxInputWordLen() (max int) {
 type int32Set map[int32]bool
 
 type state struct {
-	ID      int
+	Id      int
 	Trans   map[byte]*state
 	Output  map[byte]int32
 	Tail    int32Set
@@ -96,7 +96,7 @@ func (n *state) setTransition(ch byte, next *state) {
 	n.Trans[ch] = next
 
 	const magic = 1001
-	n.hcode += (int64(ch) + int64(next.ID)) * magic
+	n.hcode += (int64(ch) + int64(next.Id)) * magic
 }
 
 func (n *state) renew() {
@@ -147,7 +147,7 @@ func (n *state) String() string {
 	if n == nil {
 		return "<nil>"
 	}
-	ret += fmt.Sprintf("%d[%p]:", n.ID, n)
+	ret += fmt.Sprintf("%d[%p]:", n.Id, n)
 	for ch := range n.Trans {
 		ret += fmt.Sprintf("%X02/%v -->%p, ", ch, n.Output[ch], n.Trans[ch])
 	}
@@ -165,7 +165,7 @@ type mast struct {
 }
 
 func (m *mast) addState(n *state) {
-	n.ID = len(m.states)
+	n.Id = len(m.states)
 	m.states = append(m.states, n)
 	if n.IsFinal {
 		m.finalStates = append(m.finalStates, n)
@@ -311,11 +311,11 @@ func (m *mast) dot(w io.Writer) {
 	fmt.Fprintln(w, "\trankdir=LR;")
 	fmt.Fprintln(w, "\tnode [shape=circle]")
 	for _, s := range m.finalStates {
-		fmt.Fprintf(w, "\t%d [peripheries = 2];\n", s.ID)
+		fmt.Fprintf(w, "\t%d [peripheries = 2];\n", s.Id)
 	}
 	for _, from := range m.states {
 		for in, to := range from.Trans {
-			fmt.Fprintf(w, "\t%d -> %d [label=\"%02X/%v", from.ID, to.ID, in, from.Output[in])
+			fmt.Fprintf(w, "\t%d -> %d [label=\"%02X/%v", from.Id, to.Id, in, from.Output[in])
 			if to.hasTail() {
 				fmt.Fprintf(w, " %v", to.tails())
 			}
@@ -402,9 +402,9 @@ func (m mast) buildMachine() (t FST, err error) {
 			ch := edges[size-1-i]
 			next := s.Trans[ch]
 			out := s.Output[ch]
-			addr, ok := addrMap[next.ID]
+			addr, ok := addrMap[next.Id]
 			if !ok && !next.IsFinal {
-				err = fmt.Errorf("next addr is undefined: state(%v), input(%X)", s.ID, ch)
+				err = fmt.Errorf("next addr is undefined: state(%v), input(%X)", s.Id, ch)
 				return
 			}
 			jump := len(prog) - addr + 1
@@ -466,7 +466,7 @@ func (m mast) buildMachine() (t FST, err error) {
 
 			prog = append(prog, code)
 		}
-		addrMap[s.ID] = len(prog)
+		addrMap[s.Id] = len(prog)
 	}
 	t = FST{prog: invert(prog), data: data}
 	return

--- a/fst_test.go
+++ b/fst_test.go
@@ -25,7 +25,7 @@ func TestStateEq01(t *testing.T) {
 		{pair{x: nil, y: nil}, false},
 		{pair{x: nil, y: &state{}}, false},
 		{pair{x: &state{}, y: nil}, false},
-		{pair{&state{ID: 1}, &state{ID: 2}}, true},
+		{pair{&state{Id: 1}, &state{Id: 2}}, true},
 		{pair{&state{IsFinal: true}, &state{IsFinal: false}}, false},
 		{pair{&state{Output: map[byte]int32{1: 555}}, &state{}}, false},
 		{pair{&state{Output: map[byte]int32{1: 555}}, &state{Output: map[byte]int32{1: 555}}},
@@ -47,8 +47,8 @@ func TestStateEq01(t *testing.T) {
 }
 
 func TestStateEq02(t *testing.T) {
-	x := &state{ID: 1}
-	y := &state{ID: 2}
+	x := &state{Id: 1}
+	y := &state{Id: 2}
 	a := &state{
 		Trans: map[byte]*state{1: x, 2: y},
 	}
@@ -90,7 +90,7 @@ func TestStateString01(t *testing.T) {
 	}
 	r := &state{}
 	s := state{
-		ID:      1,
+		Id:      1,
 		Trans:   map[byte]*state{1: nil, 2: r},
 		Output:  map[byte]int32{3: 555, 4: 888},
 		Tail:    int32Set{1111: true},
@@ -103,8 +103,8 @@ func TestStateString01(t *testing.T) {
 func TestMASTBuildMAST01(t *testing.T) {
 	inp := PairSlice{}
 	m := buildMAST(inp)
-	if m.initialState.ID != 0 {
-		t.Errorf("got initial state id %v, expected 0\n", m.initialState.ID)
+	if m.initialState.Id != 0 {
+		t.Errorf("got initial state id %v, expected 0\n", m.initialState.Id)
 	}
 	if len(m.states) != 1 {
 		t.Errorf("expected: initial state only, got %v\n", m.states)

--- a/lattice_test.go
+++ b/lattice_test.go
@@ -9,9 +9,7 @@
 
 package kagome
 
-import (
-	"testing"
-)
+import "testing"
 
 func TestLatticeBuild01(t *testing.T) {
 	la := newLattice()
@@ -91,34 +89,6 @@ func TestLatticeBuild02(t *testing.T) {
 	}
 	if la.udic != nil {
 		t.Errorf("lattice initialize error: got %v, expected empty\n", la.udic)
-	}
-}
-
-func TestSetDic01(t *testing.T) {
-	la := newLattice()
-	la.setDic(nil)
-	if la.dic == nil {
-		t.Error("dic is nil\n")
-	}
-	d := NewSysDic()
-	if la.dic != d {
-		t.Errorf("got %p, expected %p\n", la.dic, d)
-	}
-}
-
-func TestSetUserDic01(t *testing.T) {
-	la := newLattice()
-	udic, e := NewUserDic("_sample/userdic.txt")
-	if e != nil {
-		t.Errorf("unexpected error: %v\n", e)
-	}
-	la.setUserDic(udic)
-	if la.udic != udic {
-		t.Errorf("got %p, expected %p", la.udic, udic)
-	}
-	la.setUserDic(nil)
-	if la.udic != nil {
-		t.Errorf("got %p, expected nil\n", la.dic)
 	}
 }
 

--- a/node.go
+++ b/node.go
@@ -9,6 +9,8 @@
 
 package kagome
 
+import "sync"
+
 // Reserved identifier of node id.
 const BosEosId int = -1
 
@@ -48,4 +50,14 @@ type node struct {
 	weight  int32
 	surface string
 	prev    *node
+}
+
+var nodePool = sync.Pool{
+	New: func() interface{} {
+		return new(node)
+	},
+}
+
+func newNode() *node {
+	return nodePool.Get().(*node)
 }

--- a/tokenizer_test.go
+++ b/tokenizer_test.go
@@ -9,9 +9,7 @@
 
 package kagome
 
-import (
-	"testing"
-)
+import "testing"
 
 func TestTokenize01(t *testing.T) {
 	tnz := NewTokenizer()


### PR DESCRIPTION
Tokenize() メソッドがスレッドセーフになっていなかったバグの修正
* Tokenizer() 内で，ラティスを毎回生成するように修正
* 生成したラティスを改修して再利用するように修正