### PR TITLE
added comments for exported funcs

### DIFF
--- a/cmd/kagome/lattice/cmd.go
+++ b/cmd/kagome/lattice/cmd.go
@@ -73,6 +73,7 @@ func (o *option) parse(args []string) (err error) {
 	return
 }
 
+//OptionCheck receives a slice of args and returns an error if it was not successfully parsed
 func OptionCheck(args []string) (err error) {
 	opt := newOption(ioutil.Discard, flag.ContinueOnError)
 	if e := opt.parse(args); e != nil {
@@ -136,6 +137,7 @@ func command(opt *option) error {
 	return nil
 }
 
+// Run receives the slice of args and executes the lattice tool
 func Run(args []string) error {
 	opt := newOption(ErrorWriter, flag.ExitOnError)
 	if e := opt.parse(args); e != nil {
@@ -146,10 +148,12 @@ func Run(args []string) error {
 	return command(opt)
 }
 
+// Usage provides information on the use of the lattice tool
 func Usage() {
 	fmt.Fprintf(ErrorWriter, UsageMessage, CommandName)
 }
 
+// PrintDefaults prints out the default flags
 func PrintDefaults(eh flag.ErrorHandling) {
 	o := newOption(ErrorWriter, eh)
 	o.flagSet.PrintDefaults()

--- a/cmd/kagome/main.go
+++ b/cmd/kagome/main.go
@@ -56,11 +56,13 @@ var (
 	defaultSubcommand = subcommands[0]
 )
 
+//Usage prints to stdout information about the tool
 func Usage() {
 	fmt.Fprintf(errorWriter, "Japanese Morphological Analyzer -- github.com/ikawaha/kagome\n")
 	fmt.Fprintf(errorWriter, "usage: %s <command>\n", path.Base(os.Args[0]))
 }
 
+// PrintDefaults prints out the default flags
 func PrintDefaults() {
 	fmt.Fprintln(errorWriter, "The commands are:")
 	for _, c := range subcommands {

--- a/cmd/kagome/server/cmd.go
+++ b/cmd/kagome/server/cmd.go
@@ -77,6 +77,7 @@ func (o *option) parse(args []string) (err error) {
 	return
 }
 
+//OptionCheck receives a slice of args and returns an error if it was not successfully parsed
 func OptionCheck(args []string) (err error) {
 	opt := newOption(ioutil.Discard, flag.ContinueOnError)
 	if e := opt.parse(args); e != nil {
@@ -113,6 +114,7 @@ func command(opt *option) error {
 	return nil
 }
 
+// TokenizeHandler represents the tokenizer API server struct
 type TokenizeHandler struct {
 	tokenizer tokenizer.Tokenizer
 }
@@ -184,6 +186,7 @@ func (h *TokenizeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+//TokenizeDemoHandler represents the tokenizer demo server struct
 type TokenizeDemoHandler struct {
 	tokenizer tokenizer.Tokenizer
 }
@@ -231,8 +234,8 @@ func (h *TokenizeDemoHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 		m = tokenizer.Extended
 	}
 	if _, e := exec.LookPath(graphvizCmd); e != nil {
-		cmdErr = "Error: graphviz is not in your furure"
-		log.Print("graphviz is not in your future\n")
+		cmdErr = "Error: circo/graphviz is not installed in your $PATH"
+		log.Print("Error: circo/graphviz is not installed in your $PATH\n")
 	} else {
 		var buf bytes.Buffer
 		cmd := exec.Command("dot", "-Tsvg")
@@ -318,6 +321,7 @@ func (h *TokenizeDemoHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 	}
 }
 
+// Run receives the slice of args and executes the server
 func Run(args []string) error {
 	opt := newOption(ErrorWriter, flag.ExitOnError)
 	if e := opt.parse(args); e != nil {
@@ -328,10 +332,12 @@ func Run(args []string) error {
 	return command(opt)
 }
 
+// Usage provides information on the use of the server
 func Usage() {
 	fmt.Fprintf(os.Stderr, usageMessage, CommandName)
 }
 
+// PrintDefaults prints out the default flags
 func PrintDefaults(eh flag.ErrorHandling) {
 	o := newOption(ErrorWriter, eh)
 	o.flagSet.PrintDefaults()

--- a/cmd/kagome/tokenize/cmd.go
+++ b/cmd/kagome/tokenize/cmd.go
@@ -33,6 +33,7 @@ const (
 	usageMessage = "%s [-file input_file] [-dic dic_file] [-udic userdic_file] [-sysdic (ipa|uni)] [-mode (normal|search|extended)]\n"
 )
 
+// ErrorWriter writes to stderr
 var (
 	ErrorWriter = os.Stderr
 )
@@ -82,6 +83,7 @@ func (o *option) parse(args []string) (err error) {
 	return
 }
 
+//OptionCheck receives a slice of args and returns an error if it was not successfully parsed
 func OptionCheck(args []string) (err error) {
 	opt := newOption(ioutil.Discard, flag.ContinueOnError)
 	if e := opt.parse(args); e != nil {
@@ -157,6 +159,7 @@ func command(opt *option) error {
 	return scanner.Err()
 }
 
+// Run receives the slice of args and executes the tokenize tool
 func Run(args []string) error {
 	opt := newOption(ErrorWriter, flag.ExitOnError)
 	if e := opt.parse(args); e != nil {
@@ -167,10 +170,12 @@ func Run(args []string) error {
 	return command(opt)
 }
 
+// Usage provides information on the use of the tokenize tool
 func Usage() {
 	fmt.Fprintf(ErrorWriter, usageMessage, CommandName)
 }
 
+// PrintDefaults prints out the default flags
 func PrintDefaults(eh flag.ErrorHandling) {
 	o := newOption(ErrorWriter, eh)
 	o.flagSet.PrintDefaults()


### PR DESCRIPTION
- Fixed some English spelling errors
- Fixed errors returned by `golint` (mostly regarding uncommented exported funcs)