### PR TITLE
Load user dictionary from io.Reader

### DIFF
--- a/internal/dic/udic.go
+++ b/internal/dic/udic.go
@@ -17,6 +17,7 @@ package dic
 import (
 	"bufio"
 	"fmt"
+	"io"
 	"os"
 	"sort"
 	"strings"
@@ -35,20 +36,14 @@ type UserDic struct {
 	Contents []UserDicContent
 }
 
-// NewUserDic build a user dictionary from a file.
-func NewUserDic(path string) (udic *UserDic, err error) {
+// NewUserDicFromReader build a user dictionary from io.Reader.
+func NewUserDicFromReader(r io.Reader) (udic *UserDic, err error) {
+	udic = new(UserDic)
 	const (
 		userDicColumnSize = 4
 	)
-	udic = new(UserDic)
-	f, err := os.Open(path)
-	if err != nil {
-		return
-	}
-	defer f.Close()
-
 	var text []string
-	scanner := bufio.NewScanner(f)
+	scanner := bufio.NewScanner(r)
 	for scanner.Scan() {
 		line := scanner.Text()
 		if line == "" || strings.HasPrefix(line, "#") {
@@ -86,4 +81,14 @@ func NewUserDic(path string) (udic *UserDic, err error) {
 	}
 	udic.Index, err = BuildIndexTable(keys)
 	return
+}
+
+// NewUserDic build a user dictionary from a file.
+func NewUserDic(path string) (udic *UserDic, err error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	return NewUserDicFromReader(f)
 }

--- a/tokenizer/dic.go
+++ b/tokenizer/dic.go
@@ -14,7 +14,11 @@
 
 package tokenizer
 
-import "github.com/ikawaha/kagome/internal/dic"
+import (
+	"io"
+
+	"github.com/ikawaha/kagome/internal/dic"
+)
 
 // Dic represents a dictionary.
 type Dic struct {
@@ -45,6 +49,12 @@ func SysDicUni() Dic {
 func NewDic(path string) (Dic, error) {
 	d, err := dic.Load(path)
 	return Dic{d}, err
+}
+
+// NewUserDicFromReader build a user dictionary from io.Reader.
+func NewUserDicFromReader(r io.Reader) (UserDic, error) {
+	d, err := dic.NewUserDicFromReader(r)
+	return UserDic{d}, err
 }
 
 // NewUserDic build a user dictionary from a file.


### PR DESCRIPTION
To provide more flexibility, this patch enable to load user dictionary from io.Reader. It's not breaking any compatibility.

For example, this can be acceptable. 

```go
func TestNewUserDic02(t *testing.T) {
	r := strings.NewReader(`日本経済新聞,日本 経済 新聞,ニホン ケイザイ シンブン,カスタム名詞`)
	if _, e := NewUserDicFromReader(r); e != nil {
		t.Fatalf("cannot initialize user dictionary from reader: %s", e)
	}
}
```