### PR TITLE
Use callback function instead of retun values in common-prefix search

### DIFF
--- a/internal/da/da.go
+++ b/internal/da/da.go
@@ -111,7 +111,7 @@ func (d DoubleArray) CommonPrefixSearch(input string) (ids, lens []int) {
 }
 
 // CommonPrefixSearchCallback finds keywords sharing common prefix in an input
-// and call back with id and length
+// and callback with id and length.
 func (d DoubleArray) CommonPrefixSearchCallback(input string, callback func(id, size int)) {
 	var p, q int
 	bufLen := len(d)

--- a/internal/da/da.go
+++ b/internal/da/da.go
@@ -110,6 +110,25 @@ func (d DoubleArray) CommonPrefixSearch(input string) (ids, lens []int) {
 	return
 }
 
+// CommonPrefixSearchCallback finds keywords sharing common prefix in an input
+// and call back with id and length
+func (d DoubleArray) CommonPrefixSearchCallback(input string, callback func(id, size int)) {
+	var p, q int
+	bufLen := len(d)
+	for i, size := 0, len(input); i < size; i++ {
+		p = q
+		q = int(d[p].Base) + int(input[i])
+		if q >= bufLen || int(d[q].Check) != p {
+			break
+		}
+		ahead := int(d[q].Base) + int(terminator)
+		if ahead < bufLen && int(d[ahead].Check) == q && int(d[ahead].Base) <= 0 {
+			callback(int(-d[ahead].Base), i+1)
+		}
+	}
+	return
+}
+
 // PrefixSearch returns the longest commom prefix keyword in an input if found.
 func (d DoubleArray) PrefixSearch(input string) (id int, ok bool) {
 	var p, q, i int

--- a/internal/da/da.go
+++ b/internal/da/da.go
@@ -112,10 +112,10 @@ func (d DoubleArray) CommonPrefixSearch(input string) (ids, lens []int) {
 
 // CommonPrefixSearchCallback finds keywords sharing common prefix in an input
 // and callback with id and length.
-func (d DoubleArray) CommonPrefixSearchCallback(input string, callback func(id, size int)) {
+func (d DoubleArray) CommonPrefixSearchCallback(input string, callback func(id, l int)) {
 	var p, q int
 	bufLen := len(d)
-	for i, size := 0, len(input); i < size; i++ {
+	for i := 0; i < len(input); i++ {
 		p = q
 		q = int(d[p].Base) + int(input[i])
 		if q >= bufLen || int(d[q].Check) != p {

--- a/internal/da/da_test.go
+++ b/internal/da/da_test.go
@@ -135,7 +135,7 @@ func TestDaBuildAndCommonPrefixSearchCallback01(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	d.CommonPrefixSearchCallback("", func(id, l int) {
-		t.Errorf("unexpected callback, id:%v, l:%v")
+		t.Errorf("unexpected callback, id:%v, l:%v", id, l)
 	})
 }
 
@@ -145,7 +145,7 @@ func TestDaBuildAndCommonPrefixSearchCallback02(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	d.CommonPrefixSearchCallback("", func(id, l int) {
-		t.Errorf("unexpected callback, id:%v, l:%v")
+		t.Errorf("unexpected callback, id:%v, l:%v", id, l)
 	})
 }
 

--- a/internal/da/da_test.go
+++ b/internal/da/da_test.go
@@ -129,6 +129,62 @@ func TestDaBuildAndCommonPrefixSearch03(t *testing.T) {
 	}
 }
 
+func TestDaBuildAndCommonPrefixSearchCallback01(t *testing.T) {
+	d, err := Build(nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	d.CommonPrefixSearchCallback("", func(id, l int) {
+		t.Errorf("unexpected callback, id:%v, l:%v")
+	})
+}
+
+func TestDaBuildAndCommonPrefixSearchCallback02(t *testing.T) {
+	d, err := Build([]string{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	d.CommonPrefixSearchCallback("", func(id, l int) {
+		t.Errorf("unexpected callback, id:%v, l:%v")
+	})
+}
+
+func TestDaBuildAndCommonPrefixSearchCallback03(t *testing.T) {
+	keywords := []string{
+		"電気通信",              //1
+		"電気",                //2
+		"電気通信大学",            //3
+		"電気通信大学院大学",         //4
+		"電気通信大学大学院",         //5
+		"電気通信大学大学院電気通信学研究科", //6
+		"電気通信大学電気通信学部",      //7
+	}
+	d, err := Build(keywords)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expected := []struct {
+		id, l int
+	}{
+		{2, 3 * 2},  //"電気"
+		{1, 3 * 4},  //"電気通信"
+		{3, 3 * 6},  //"電気通信大学"
+		{5, 3 * 9},  //"電気通信大学大学院"
+		{6, 3 * 17}, //"電気通信大学大学院電気通信学研究科"
+	}
+
+	var i int
+	d.CommonPrefixSearchCallback("電気通信大学大学院電気通信学研究科", func(id, l int) {
+		if expected[i].id != id {
+			t.Errorf("id: got %v, expected %v", id, expected[i].id)
+		}
+		if expected[i].l != l {
+			t.Errorf("len: got %v, expected %v", l, expected[i].l)
+		}
+		i++
+	})
+}
+
 func TestDaBuildWithIDsAndCommonPrefixSearch01(t *testing.T) {
 	d, err := BuildWithIDs(nil, nil)
 	if err != nil {

--- a/internal/dic/index.go
+++ b/internal/dic/index.go
@@ -77,11 +77,11 @@ func (idx IndexTable) CommonPrefixSearch(input string) (lens []int, ids [][]int)
 
 // CommonPrefixSearchCallback finds keywords sharing common prefix in an input
 // and callback with id and length.
-func (idx IndexTable) CommonPrefixSearchCallback(input string, callback func(int, int)) {
-	idx.Da.CommonPrefixSearchCallback(input, func(id, l int) {
-		dup, _ := idx.Dup[int32(id)]
-		for i := id; i < id+int(dup)+1; i++ {
-			callback(i, l)
+func (idx IndexTable) CommonPrefixSearchCallback(input string, callback func(id, l int)) {
+	idx.Da.CommonPrefixSearchCallback(input, func(x, y int) {
+		dup := idx.Dup[int32(x)]
+		for i := x; i < x+int(dup)+1; i++ {
+			callback(i, y)
 		}
 	})
 	return

--- a/internal/dic/index.go
+++ b/internal/dic/index.go
@@ -75,8 +75,8 @@ func (idx IndexTable) CommonPrefixSearch(input string) (lens []int, ids [][]int)
 	return
 }
 
-// CommonPrefixSearch finds keywords sharing common prefix in an input
-// and returns the ids and it's lengths if found.
+// CommonPrefixSearchCallback finds keywords sharing common prefix in an input
+// and callback with id and length.
 func (idx IndexTable) CommonPrefixSearchCallback(input string, callback func(int, int)) {
 	idx.Da.CommonPrefixSearchCallback(input, func(id, l int) {
 		dup, _ := idx.Dup[int32(id)]

--- a/internal/dic/index.go
+++ b/internal/dic/index.go
@@ -75,6 +75,18 @@ func (idx IndexTable) CommonPrefixSearch(input string) (lens []int, ids [][]int)
 	return
 }
 
+// CommonPrefixSearch finds keywords sharing common prefix in an input
+// and returns the ids and it's lengths if found.
+func (idx IndexTable) CommonPrefixSearchCallback(input string, callback func(int, int)) {
+	idx.Da.CommonPrefixSearchCallback(input, func(id, l int) {
+		dup, _ := idx.Dup[int32(id)]
+		for i := id; i < id+int(dup)+1; i++ {
+			callback(i, l)
+		}
+	})
+	return
+}
+
 // Search finds the given keyword and returns the id if found.
 func (idx IndexTable) Search(input string) []int {
 	id, ok := idx.Da.Find(input)

--- a/internal/dic/index_test.go
+++ b/internal/dic/index_test.go
@@ -82,6 +82,44 @@ func TestCommonPrefixSearch(t *testing.T) {
 	}
 }
 
+func TestCommonPrefixSearchCallback(t *testing.T) {
+	sortedKeywords := []string{
+		"す",    //0
+		"すし",   //1
+		"すし",   //2
+		"すし",   //3
+		"すし",   //4
+		"すしめし", //5
+		"すしめし", //6
+	}
+	expected := []struct {
+		id, l int
+	}{
+		{0, 3},
+		{1, 6},
+		{2, 6},
+		{3, 6},
+		{4, 6},
+		{5, 12},
+		{6, 12},
+	}
+	idx, err := BuildIndexTable(sortedKeywords)
+	if err != nil {
+		t.Fatalf("unexpected error, %v", err)
+	}
+
+	var i int
+	idx.CommonPrefixSearchCallback("すしめしたべた", func(id, l int) {
+		if expected[i].id != id {
+			t.Errorf("common prefix search callback id, got %v, expected %v", id, expected[i].id)
+		}
+		if expected[i].l != l {
+			t.Errorf("common prefix search callback len, got %v, expected %v", l, expected[i].l)
+		}
+		i++
+	})
+}
+
 func TestSearch(t *testing.T) {
 	sortedKeywords := []string{
 		"す",    //0

--- a/internal/dic/trie.go
+++ b/internal/dic/trie.go
@@ -19,4 +19,5 @@ type Trie interface {
 	Search(input string) []int32
 	PrefixSearch(input string) (length int, output []int32)
 	CommonPrefixSearch(input string) (lens []int, outputs [][]int32)
+	CommonPrefixSearchCallback(input string, callback func(id, l int))
 }


### PR DESCRIPTION
re: #75 

before
```
$ go test --bench .
PASS
BenchmarkAnalyzeNormal-4         10000        222285 ns/op
BenchmarkAnalyzeSearch-4          5000        290241 ns/op
BenchmarkAnalyzeExtended-4        5000        295677 ns/op
ok      github.com/ikawaha/kagome/tokenizer    21.251s
```

after
```
go test --bench .
PASS
BenchmarkAnalyzeNormal-4         10000        158133 ns/op
BenchmarkAnalyzeSearch-4         10000        227858 ns/op
BenchmarkAnalyzeExtended-4       10000        235153 ns/op
ok      github.com/ikawaha/kagome/tokenizer    22.270s
```

alloc_space
```
$ go tool pprof --alloc_space tokenizer.test fix_mem.prof
Entering interactive mode (type "help" for commands)
(pprof) top
1020.66MB of 1033.17MB total (98.79%)
Dropped 27 nodes (cum <= 5.17MB)
Showing top 10 nodes out of 44 (cum >= 7.50MB)
      flat  flat%   sum%        cum   cum%
  773.95MB 74.91% 74.91%   775.96MB 75.10%  github.com/ikawaha/kagome/tokenizer.Tokenizer.Analyze
  114.31MB 11.06% 85.97%   114.31MB 11.06%  bytes.makeSlice
   60.99MB  5.90% 91.88%    60.99MB  5.90%  strings.genSplit
   46.50MB  4.50% 96.38%    46.50MB  4.50%  encoding/binary.Read
   10.34MB  1.00% 97.38%    32.84MB  3.18%  github.com/ikawaha/kagome/internal/da.Read
    8.98MB  0.87% 98.25%    69.97MB  6.77%  github.com/ikawaha/kagome/internal/dic.NewContents
    3.31MB  0.32% 98.57%    20.31MB  1.97%  github.com/ikawaha/kagome/internal/dic.LoadConnectionTable
    2.28MB  0.22% 98.79%     9.28MB   0.9%  github.com/ikawaha/kagome/internal/dic.LoadMorphSlice
         0     0% 98.79%   117.31MB 11.35%  bytes.(*Buffer).ReadFrom
         0     0% 98.79%     7.50MB  0.73%  encoding/gob.(*Decoder).Decode
```