### PR TITLE
Fix out of range error

### DIFF
--- a/internal/dic/dic.go
+++ b/internal/dic/dic.go
@@ -40,7 +40,7 @@ type Dic struct {
 
 // CharacterCategory returns the category of a rune.
 func (d Dic) CharacterCategory(r rune) byte {
-	if int(r) <= len(d.CharCategory) {
+	if int(r) < len(d.CharCategory) {
 		return d.CharCategory[r]
 	}
 	return d.CharCategory[0] // default

--- a/internal/dic/dic_test.go
+++ b/internal/dic/dic_test.go
@@ -310,7 +310,7 @@ func TestCharCategory02(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	c := dic.CharacterCategory(rune(len(dic.CharCategory) + 1))
+	c := dic.CharacterCategory(rune(len(dic.CharCategory)))
 	expected := dic.CharCategory[0]
 	if c != expected {
 		t.Errorf("got %v, expected %v", c, expected)


### PR DESCRIPTION
Hi, thank you for your useful library :)
I probably found a bug about `out of range error`.
This error can be reproduced by pass [`0x10000`](http://www.fileformat.info/info/unicode/char/10000/index.htm) to `CharacterCategory(r rune) byte` of `SysDic`.
For details, please review my modifications.