### PR TITLE
[WIP][_dictool] mecabサブコマンドの追加

### DIFF
--- a/cmd/_dictool/main.go
+++ b/cmd/_dictool/main.go
@@ -20,6 +20,7 @@ import (
 	"path/filepath"
 
 	"github.com/ikawaha/kagome/cmd/_dictool/ipa"
+	"github.com/ikawaha/kagome/cmd/_dictool/mecab"
 	"github.com/ikawaha/kagome/cmd/_dictool/uni"
 )
 
@@ -33,6 +34,7 @@ var subcommands = []struct {
 	// subcommands
 	{ipa.CommandName, ipa.Description, ipa.Run},
 	{uni.CommandName, uni.Description, uni.Run},
+	{mecab.CommandName, mecab.Description, mecab.Run},
 }
 
 func Usage() {

--- a/cmd/_dictool/mecab/cmd.go
+++ b/cmd/_dictool/mecab/cmd.go
@@ -1,0 +1,102 @@
+// Copyright 2015 ikawaha
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// 	You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mecab
+
+import (
+	"flag"
+	"fmt"
+	"os"
+)
+
+// subcommand property
+var (
+	CommandName  = "mecab"
+	Description  = `mecab dic build tool`
+	usageMessage = "%s -mecab mecabdic-path [-z]\n"
+	errorWriter  = os.Stderr
+)
+
+// options
+type option struct {
+	output   string
+	mecab    string
+	archive  bool
+	encoding string
+
+	flagSet *flag.FlagSet
+}
+
+func newOption() (o *option) {
+	o = &option{
+		flagSet: flag.NewFlagSet(CommandName, flag.ContinueOnError),
+	}
+	// option settings
+	o.flagSet.BoolVar(&o.archive, "z", true, "build an archived dic")
+	o.flagSet.StringVar(&o.output, "output", "mecab.dic", "set output path")
+	o.flagSet.StringVar(&o.mecab, "mecab", "", "set mecab src path")
+	o.flagSet.StringVar(&o.encoding, "encoding", "utf8", "set mecab src encoding [utf8|eucjp|sjis|jis]")
+	return
+}
+
+func (o *option) parse(args []string) (err error) {
+	if err = o.flagSet.Parse(args); err != nil {
+		return
+	}
+	// validations
+	if nonFlag := o.flagSet.Args(); len(nonFlag) != 0 {
+		return fmt.Errorf("invalid argument: %v", nonFlag)
+	}
+	if o.mecab == "" {
+		return fmt.Errorf("invalid argument: -mecab")
+	}
+	return
+}
+
+// command main
+func command(opt *option) error {
+	d, err := buildMecabDic(opt.mecab, opt.encoding)
+	if err != nil {
+		return err
+	}
+	if saveMecabDic(d, opt.output, opt.archive); err != nil {
+		return fmt.Errorf("build error: %v", err)
+	}
+	return nil
+}
+
+// Run mecab command
+func Run(args []string) error {
+	if len(args) == 0 {
+		usage()
+		printDefaults()
+		return nil
+	}
+	opt := newOption()
+	if e := opt.parse(args); e != nil {
+		usage()
+		printDefaults()
+		return e
+	}
+	return command(opt)
+}
+
+func usage() {
+	fmt.Fprintf(os.Stderr, usageMessage, CommandName)
+}
+
+func printDefaults() {
+	o := newOption()
+	o.flagSet.PrintDefaults()
+}

--- a/cmd/_dictool/mecab/mkdic.go
+++ b/cmd/_dictool/mecab/mkdic.go
@@ -1,0 +1,535 @@
+// Copyright 2015 ikawaha
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// 	You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mecab
+
+import (
+	"archive/zip"
+	"bufio"
+	"bytes"
+	"compress/flate"
+	"encoding/csv"
+	"encoding/gob"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+
+	"golang.org/x/text/encoding/japanese"
+	"golang.org/x/text/transform"
+
+	"github.com/ikawaha/kagome/cmd/_dictool/splitfile"
+	"github.com/ikawaha/kagome/internal/dic"
+)
+
+const (
+	mecabMatrixDefFileName = "matrix.def"
+	mecabCharDefFileName   = "char.def"
+	mecabUnkDefFileName    = "unk.def"
+
+	mecabDicDefaultArchiveFileName = "mecab.dic"
+
+	mecabDicMorphFileName      = "morph.dic"
+	mecabDicPOSFileName        = "pos.dic"
+	mecabDicContentFileName    = "content.dic"
+	mecabDicIndexFileName      = "index.dic"
+	mecabDicConnectionFileName = "connection.dic"
+	mecabDicCharDefFileName    = "chardef.dic"
+	mecabDicUnkFileName        = "unk.dic"
+
+	mecabMrophRecordSurfaceIndex            = 0
+	mecabMorphRecordLeftIDIndex             = 1
+	mecabMorphRecordRightIDIndex            = 2
+	mecabMorphRecordWeightIndex             = 3
+	mecabMorphRecordPOSRecordStartIndex     = 4
+	mecabMorphRecordOtherContentsStartIndex = 10
+	mecabMorphCsvColMinSize                 = mecabMorphRecordOtherContentsStartIndex + 1
+
+	mecabUnkRecordCategoryIndex           = 0
+	mecabUnkRecordLeftIDIndex             = 1
+	mecabUnkRecordRightIndex              = 2
+	mecabUnkRecordWeigthIndex             = 3
+	mecabUnkRecordOtherContentsStartIndex = 4
+	mecabUnkRecordMinSize                 = mecabUnkRecordOtherContentsStartIndex + 1
+)
+
+type mecabDic struct {
+	Morphs       []dic.Morph
+	POSTable     dic.POSTable
+	Contents     [][]string
+	Index        dic.IndexTable
+	Connection   dic.ConnectionTable
+	CharClass    []string
+	CharCategory []byte
+	InvokeList   []bool
+	GroupList    []bool
+
+	dic.UnkDic
+}
+
+type mecabDicPath struct {
+	Morph      string
+	POS        string
+	Index      string
+	Connection string
+	CharDef    string
+	Unk        string
+}
+
+type mecabMorphRecordSlice [][]string
+
+func (p mecabMorphRecordSlice) Len() int           { return len(p) }
+func (p mecabMorphRecordSlice) Less(i, j int) bool { return p[i][0] < p[j][0] }
+func (p mecabMorphRecordSlice) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
+
+func saveMecabDic(d *mecabDic, output string, archive bool) error {
+	var zw *zip.Writer
+	if fi, err := os.Stat(output); err == nil && fi.IsDir() {
+		output = filepath.Join(output, mecabDicDefaultArchiveFileName)
+	}
+	if archive {
+		f, err := os.Create(output)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		zw = zip.NewWriter(f)
+	} else {
+		f, err := splitfile.Open(output, 10*1024*1024) // 10MB
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		zw = zip.NewWriter(f)
+		zw.RegisterCompressor(zip.Deflate, func(out io.Writer) (io.WriteCloser, error) {
+			return flate.NewWriter(out, flate.NoCompression)
+		})
+		if err != nil {
+			return err
+		}
+
+	}
+
+	if err := func() error {
+		out, err := zw.Create(mecabDicMorphFileName)
+		if err != nil {
+			return err
+		}
+		_, err = dic.MorphSlice(d.Morphs).WriteTo(out)
+		return err
+	}(); err != nil {
+		return err
+	}
+
+	if err := func() (e error) {
+		out, err := zw.Create(mecabDicPOSFileName)
+		if err != nil {
+			return err
+		}
+		_, err = dic.POSTable(d.POSTable).WriteTo(out)
+		return err
+	}(); err != nil {
+		return err
+	}
+
+	if err := func() error {
+		out, err := zw.Create(mecabDicContentFileName)
+		if err != nil {
+			return err
+		}
+		_, err = dic.Contents(d.Contents).WriteTo(out)
+		return err
+	}(); err != nil {
+		return err
+	}
+
+	if err := func() error {
+		out, err := zw.Create(mecabDicIndexFileName)
+		if err != nil {
+			return err
+		}
+		_, err = d.Index.WriteTo(out)
+		return err
+	}(); err != nil {
+		return err
+	}
+
+	if err := func() error {
+		out, err := zw.Create(mecabDicConnectionFileName)
+		if err != nil {
+			return err
+		}
+		_, err = d.Connection.WriteTo(out)
+		return err
+	}(); err != nil {
+		return err
+	}
+
+	if err := func() error {
+		out, err := zw.Create(mecabDicCharDefFileName)
+		if err != nil {
+			return err
+		}
+
+		var buf bytes.Buffer
+		enc := gob.NewEncoder(&buf)
+		if err := enc.Encode(d.CharClass); err != nil {
+			return err
+		}
+		if _, err := buf.WriteTo(out); err != nil {
+			return err
+		}
+		if err := enc.Encode(d.CharCategory); err != nil {
+			return err
+		}
+		if _, err := buf.WriteTo(out); err != nil {
+			return err
+		}
+		if err := enc.Encode(d.InvokeList); err != nil {
+			return err
+		}
+		if _, err := buf.WriteTo(out); err != nil {
+			return err
+		}
+		if err := enc.Encode(d.GroupList); err != nil {
+			return err
+		}
+		if _, err := buf.WriteTo(out); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		return err
+	}
+
+	if err := func() error {
+		out, err := zw.Create(mecabDicUnkFileName)
+		if err != nil {
+			return err
+		}
+		if _, err := d.UnkDic.WriteTo(out); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		return err
+	}
+
+	return zw.Close()
+}
+
+func buildMecabDic(mecabPath string, encoding string) (d *mecabDic, err error) {
+	// Morphs, Contents, Index
+	var files []string
+	files, err = filepath.Glob(mecabPath + "/*.csv")
+	if err != nil {
+		return
+	}
+	var records mecabMorphRecordSlice
+	for _, file := range files {
+		if err = func() error {
+			f, e := os.Open(file)
+			if e != nil {
+				return e
+			}
+			defer f.Close()
+
+			var _r io.Reader
+			switch encoding {
+			case "sjis":
+				_r = transform.NewReader(f, japanese.ShiftJIS.NewDecoder())
+			case "eucjp":
+				_r = transform.NewReader(f, japanese.EUCJP.NewDecoder())
+			case "jis":
+				_r = transform.NewReader(f, japanese.ISO2022JP.NewDecoder())
+			default:
+				_r = f
+			}
+			r := csv.NewReader(_r)
+			r.Comma = ','
+			r.LazyQuotes = true
+			for {
+				rec, e := r.Read()
+				if e == io.EOF {
+					break
+				} else if e != nil {
+					return e
+				} else if len(rec) < mecabMorphCsvColMinSize {
+					return fmt.Errorf("invalid format csv: %v, %v", file, rec)
+				}
+				records = append(records, rec)
+			}
+			return nil
+		}(); err != nil {
+			return
+		}
+	}
+
+	sort.Sort(records)
+	d = new(mecabDic)
+	d.Morphs = make([]dic.Morph, 0, len(records))
+	d.POSTable = dic.POSTable{
+		POSs: make([]dic.POS, 0, len(records)),
+	}
+	d.Contents = make([][]string, 0, len(records))
+	var (
+		keywords []string
+		posMap   = make(dic.POSMap)
+	)
+	for _, rec := range records {
+		keywords = append(keywords, rec[mecabMrophRecordSurfaceIndex])
+		var l, r, w int
+		if l, err = strconv.Atoi(rec[mecabMorphRecordLeftIDIndex]); err != nil {
+			return
+		}
+		if r, err = strconv.Atoi(rec[mecabMorphRecordRightIDIndex]); err != nil {
+			return
+		}
+		if w, err = strconv.Atoi(rec[mecabMorphRecordWeightIndex]); err != nil {
+			return
+		}
+		m := dic.Morph{LeftID: int16(l), RightID: int16(r), Weight: int16(w)}
+		d.Morphs = append(d.Morphs, m)
+		d.POSTable.POSs = append(d.POSTable.POSs, posMap.Add(
+			rec[mecabMorphRecordPOSRecordStartIndex:mecabMorphRecordOtherContentsStartIndex]),
+		)
+		d.Contents = append(d.Contents, rec[mecabMorphRecordOtherContentsStartIndex:])
+	}
+	d.POSTable.NameList = posMap.List()
+
+	if d.Index, err = dic.BuildIndexTable(keywords); err != nil {
+		return
+	}
+
+	// ConnectionTable
+	r, c, v, e := loadMecabMatrixDefFile(mecabPath + "/" + mecabMatrixDefFileName)
+	if e != nil {
+		err = e
+		return
+	}
+
+	d.Connection.Row = r
+	d.Connection.Col = c
+	d.Connection.Vec = v
+
+	// CharDef
+	cc, cm, inv, grp, e := loadMecabCharClassDefFile(mecabPath + "/" + mecabCharDefFileName)
+	if e != nil {
+		err = e
+		return
+	}
+
+	d.CharClass = cc
+	d.CharCategory = cm
+	d.InvokeList = inv
+	d.GroupList = grp
+
+	// Unk
+	unks, e := loadMecabUnkFile(mecabPath + "/" + mecabUnkDefFileName)
+	if e != nil {
+		err = e
+		return
+	}
+	d.UnkIndex = make(map[int32]int32)
+	d.UnkIndexDup = make(map[int32]int32)
+	sort.Sort(mecabMorphRecordSlice(unks))
+	for _, rec := range unks {
+		catid := int32(-1)
+		for id, cat := range d.CharClass {
+			if cat == rec[mecabUnkRecordCategoryIndex] {
+				catid = int32(id)
+				break
+			}
+		}
+		if catid < 0 {
+			err = fmt.Errorf("unknown unk category: %v", rec[mecabUnkRecordCategoryIndex])
+			return
+		}
+		if _, ok := d.UnkIndex[catid]; !ok {
+			d.UnkIndex[catid] = int32(len(d.UnkContents))
+		} else {
+			d.UnkIndexDup[catid]++
+		}
+		var l, r, w int
+		if l, err = strconv.Atoi(rec[mecabUnkRecordLeftIDIndex]); err != nil {
+			return
+		}
+		if r, err = strconv.Atoi(rec[mecabUnkRecordRightIndex]); err != nil {
+			return
+		}
+		if w, err = strconv.Atoi(rec[mecabUnkRecordWeigthIndex]); err != nil {
+			return
+		}
+		m := dic.Morph{LeftID: int16(l), RightID: int16(r), Weight: int16(w)}
+		d.UnkMorphs = append(d.UnkMorphs, m)
+		d.UnkContents = append(d.UnkContents, rec[mecabUnkRecordOtherContentsStartIndex:])
+	}
+	return
+}
+
+func loadMecabMorphFile(path string) (records [][]string, err error) {
+	var f *os.File
+	f, err = os.Open(path)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	r := csv.NewReader(transform.NewReader(f, japanese.EUCJP.NewDecoder()))
+	r.Comma = ','
+	for {
+		record, e := r.Read()
+		if e == io.EOF {
+			break
+		} else if e != nil {
+			err = e
+			return
+		}
+		records = append(records, record)
+	}
+	return
+}
+
+func loadMecabMatrixDefFile(path string) (rowSize, colSize int64, vec []int16, err error) {
+	var file *os.File
+	file, err = os.Open(path)
+	if err != nil {
+		return
+	}
+	defer file.Close()
+	scanner := bufio.NewScanner(file)
+	scanner.Scan()
+	line := scanner.Text()
+	dim := strings.Split(line, " ")
+	if len(dim) != 2 {
+		err = fmt.Errorf("invalid format: %s", line)
+		return
+	}
+	rowSize, err = strconv.ParseInt(dim[0], 10, 0)
+	if err != nil {
+		err = fmt.Errorf("invalid format: %s, %s", err, line)
+		return
+	}
+	colSize, err = strconv.ParseInt(dim[1], 10, 0)
+	if err != nil {
+		err = fmt.Errorf("invalid format: %s, %s", err, line)
+		return
+	}
+	vec = make([]int16, rowSize*colSize)
+	for scanner.Scan() {
+		line := scanner.Text()
+		ary := strings.Split(line, " ")
+		if len(ary) != 3 {
+			err = fmt.Errorf("invalid format: %s", line)
+			return
+		}
+		row, e := strconv.ParseInt(ary[0], 10, 0)
+		if e != nil {
+			err = fmt.Errorf("invalid format: %s, %s", e, line)
+			return
+		}
+		col, e := strconv.ParseInt(ary[1], 10, 0)
+		if e != nil {
+			err = fmt.Errorf("invalid format: %s, %s", e, line)
+			return
+		}
+		val, e := strconv.Atoi(ary[2])
+		if e != nil {
+			err = fmt.Errorf("invalid format: %s, %s", e, line)
+			return
+		}
+		vec[row*colSize+col] = int16(val)
+	}
+	if err = scanner.Err(); err != nil {
+		err = fmt.Errorf("invalid format: %s, %s", err, line)
+		return
+	}
+	return
+}
+
+func loadMecabCharClassDefFile(path string) (charClass []string, charCategory []byte, invokeMap, groupMap []bool, err error) {
+	var file *os.File
+	file, err = os.Open(path)
+	if err != nil {
+		return
+	}
+	defer file.Close()
+
+	charCategory = make([]byte, 65536)
+	charClass = make([]string, 0)
+
+	regCharClass := regexp.MustCompile("^(\\w+)\\s+(\\d+)\\s+(\\d+)\\s+(\\d+)")
+	regCharCategory := regexp.MustCompile("^(0x[0-9A-F]+)(?:\\s+([^#\\s]+))(?:\\s+([^#\\s]+))?")
+	regCharCategoryRange := regexp.MustCompile("^(0x[0-9A-F]+)..(0x[0-9A-F]+)(?:\\s+([^#\\s]+))(?:\\s+([^#\\s]+))?")
+
+	scanner := bufio.NewScanner(file)
+	cc2id := make(map[string]byte)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if len(line) == 0 || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		line = strings.TrimSpace(line)
+
+		if matches := regCharClass.FindStringSubmatch(line); len(matches) > 0 {
+			invokeMap = append(invokeMap, matches[2] == "1")
+			groupMap = append(groupMap, matches[3] == "1")
+			cc2id[matches[1]] = byte(len(charClass))
+			charClass = append(charClass, matches[1])
+		} else if matches := regCharCategory.FindStringSubmatch(line); len(matches) > 0 {
+			ch, _ := strconv.ParseInt(matches[1], 0, 0)
+			charCategory[ch] = cc2id[matches[2]]
+		} else if matches := regCharCategoryRange.FindStringSubmatch(line); len(matches) > 0 {
+			start, _ := strconv.ParseInt(matches[1], 0, 0)
+			end, _ := strconv.ParseInt(matches[2], 0, 0)
+			for x := start; x <= end; x++ {
+				charCategory[x] = cc2id[matches[3]]
+			}
+		} else {
+			err = fmt.Errorf("invalid format error: %v", line)
+			return
+		}
+
+	}
+	err = scanner.Err()
+	return
+}
+
+func loadMecabUnkFile(path string) (records [][]string, err error) {
+	var file *os.File
+	file, err = os.Open(path)
+	if err != nil {
+		return
+	}
+	r := csv.NewReader(transform.NewReader(file, japanese.EUCJP.NewDecoder()))
+	r.Comma = ','
+	for {
+		rec, e := r.Read()
+		if e == io.EOF {
+			break
+		} else if e != nil {
+			err = e
+			return
+		} else if len(rec) < mecabUnkRecordMinSize {
+			err = fmt.Errorf("invalid format csv: %v, %v", file, rec)
+			return
+		}
+		records = append(records, rec)
+	}
+	return
+}

--- a/internal/dic/pos.go
+++ b/internal/dic/pos.go
@@ -28,7 +28,7 @@ type POSTable struct {
 }
 
 // POSID represents a ID of part of speech.
-type POSID int16
+type POSID int
 
 // POS represents a vector of part of speech.
 type POS []POSID


### PR DESCRIPTION
Juman 辞書を追加するために mecab サブコマンドを追加したいです。
また、POSID 値が int16 では収まらず out of index error になってしまうため int に変更しています。
これで juman 辞書を作成できました。

```
$ curl -o mecab-master.zip https://codeload.github.com/taku910/mecab/zip/master
$ unzip mecab-master.zip
$ _dictool mecab -mecab mecab-master/mecab-jumandic -output juman.dic
```

ただし、一部辞書の作成に失敗しており、文字化けしてしまいました。
ここは現在調査中です。

```
$ kagome -dic juman.dic
マルチリンガル
マルチリンガル	���荅�,腟�膵����,*,*,*,*,*
EOS
```

