### PR TITLE
Exposed new Tokenizer constructor that loads dictionary from custom path

### DIFF
--- a/tokenizer/tokenizer.go
+++ b/tokenizer/tokenizer.go
@@ -52,6 +52,15 @@ func NewWithDic(d Dic) (t Tokenizer) {
 	return Tokenizer{dic: d.dic}
 }
 
+// NewWithDicPath create a tokenizer with a dictionary that loads from path.
+func NewWithDicPath(p string) (Tokenizer, error) {
+	d, err := dic.Load(p)
+	if err != nil {
+		return Tokenizer{}, err
+	}
+	return NewWithDic(Dic{d}), nil
+}
+
 // SetDic sets dictionary to dic.
 func (t *Tokenizer) SetDic(d Dic) {
 	t.dic = d.dic

--- a/tokenizer/tokenizer_test.go
+++ b/tokenizer/tokenizer_test.go
@@ -349,6 +349,29 @@ func TestTokenizerSetDic(t *testing.T) {
 	}
 }
 
+func TestNewWithDicPath(t *testing.T) {
+	result, err := NewWithDicPath("../_sample/ipa.dic")
+
+	if err != nil {
+		t.Errorf("got err %v loading dictionary", err)
+	}
+	exp := []string{"BOS", "こんにちは", "、", "元気", "です", "か", "？", "EOS"}
+	tokens := result.Tokenize("こんにちは、元気ですか？")
+	for i, token := range tokens {
+		if token.Surface != exp[i] {
+			t.Errorf("expected %v, got %v", exp[i], token)
+		}
+	}
+}
+
+func TestNewWithInvalidPath(t *testing.T) {
+	_, err := NewWithDicPath("invalid.zip")
+
+	if err == nil {
+		t.Errorf("no dictionary should have been loaded")
+	}
+}
+
 func TestTokenizerDot(t *testing.T) {
 	tnz := New()
 


### PR DESCRIPTION
Added test to cover this new function.

This gives users the flexibility to store dictionaries in a regular file and create tokenizers that loads from the path to that file.