### PR TITLE
Remove null bytes to avoid panic on Lattice.Build()

### DIFF
--- a/internal/lattice/lattice.go
+++ b/internal/lattice/lattice.go
@@ -17,6 +17,7 @@ package lattice
 import (
 	"fmt"
 	"io"
+	"strings"
 	"sync"
 	"unicode"
 	"unicode/utf8"
@@ -108,6 +109,7 @@ func (la *Lattice) addNode(pos, id, start int, class NodeClass, surface string) 
 
 // Build builds a lattice from the inputs.
 func (la *Lattice) Build(inp string) {
+	inp = removeNullBytes(inp)
 	rc := utf8.RuneCountInString(inp)
 	la.Input = inp
 	if cap(la.list) < rc+2 {
@@ -358,4 +360,9 @@ func (la *Lattice) Dot(w io.Writer) {
 	}
 
 	fmt.Fprintln(w, "}")
+}
+
+// removeNullBytes deletes null bytes from the given text.
+func removeNullBytes(text string) string {
+	return strings.Replace(text, "\x00", "", -1)
 }

--- a/internal/lattice/lattice_test.go
+++ b/internal/lattice/lattice_test.go
@@ -384,3 +384,33 @@ func TestBackward01(t *testing.T) {
 		la.Backward(m)
 	}
 }
+
+func TestRemoveNullBytes(t *testing.T) {
+	tests := []struct {
+		text     string
+		expected string
+	}{
+		// with null byte
+		{"\x00", ""},
+		{"\x00\x00\x00", ""},
+		{"\x00 \x00", " "},
+		{"あ\x00", "あ"},
+		{"\x00あ", "あ"},
+		{"\x00あ\x00", "あ"},
+		{"あいうえお\x00かきくけこ\x00\n\x00さしすせそ\x00\x00たちつてと\x00", "あいうえおかきくけこ\nさしすせそたちつてと"},
+		// without null byte
+		{"\x01\x02", "\x01\x02"},
+		{"", ""},
+		{" ", " "},
+		{"あ", "あ"},
+		{"\x01あ\x02", "\x01あ\x02"},
+		{"あいうえお\nかきくけこ", "あいうえお\nかきくけこ"},
+	}
+
+	for _, tt := range tests {
+		result := removeNullBytes(tt.text)
+		if result != tt.expected {
+			t.Errorf("empty bytes should be removed. got [%x], expected [%x]", result, tt.expected)
+		}
+	}
+}


### PR DESCRIPTION
## Background

When text contains null byte (`\x00`) and perform `tokenizer.Tokenize(text)`, it will emit panic (on `CommonPrefixSearchCallback`).
Tokenizer don't need the empty string to create token, so strip it in this PR.

## Benchmarks

I checked some implements.
The last one is good for performance and cleaness.

```go
func removeNullbyte1(text string) string {
	var out []byte
	for _, b := range []byte(text) {
		if b == 0 {
			continue
		}
		out = append(out, b)
	}
	return string(out)
}

func removeNullbyte2(text string) string {
	return string(bytes.Replace([]byte(text), []byte("\x00"), []byte{}, -1))
}

// use this version
func removeNullbyte3(text string) string {
	return strings.Replace(text, "\x00", "", -1)
}
```


```bash
$ go test -bench . -benchmem

goos: darwin
goarch: amd64
pkg: github.com/ikawaha
BenchmarkRemoveNullbyte1-4   	 5000000	       253 ns/op	     328 B/op	       6 allocs/op
BenchmarkRemoveNullbyte2-4   	10000000	       212 ns/op	     256 B/op	       3 allocs/op
BenchmarkRemoveNullbyte3-4   	10000000	       163 ns/op	     160 B/op	       2 allocs/op
PASS
```