### PR TITLE
fix "go get" url

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ EOS
 ## Install
 
 ```shellsession
-go get -u github.com/ikawaha/kagome/v2/...
+go get -u github.com/ikawaha/kagome/...
 ```
 
 ## Usage


### PR DESCRIPTION
The "v2" path no longer seems to be valid
```
$ go get -u github.com/ikawaha/kagome/v2/...
go: warning: "github.com/ikawaha/kagome/v2/..." matched no packages
```