### PR TITLE
Rename PickUp to Keep to clarify its purpose.

### DIFF
--- a/filter/filter.go
+++ b/filter/filter.go
@@ -9,8 +9,8 @@ func Drop(tokens *[]tokenizer.Token, match func(t tokenizer.Token) bool) {
 	applyFilter(match, tokens, true)
 }
 
-// PickUp picks up a token given the provided match function.
-func PickUp(tokens *[]tokenizer.Token, match func(t tokenizer.Token) bool) {
+// Keep keeps a token given the provided match function.
+func Keep(tokens *[]tokenizer.Token, match func(t tokenizer.Token) bool) {
 	applyFilter(match, tokens, false)
 }
 

--- a/filter/filter_test.go
+++ b/filter/filter_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/ikawaha/kagome/v2/tokenizer"
 )
 
-func TestPickup(t *testing.T) {
+func TestKeep(t *testing.T) {
 	d, err := dict.LoadDictFile(testDictPath)
 	if err != nil {
 		panic(err)
@@ -44,7 +44,7 @@ func TestPickup(t *testing.T) {
 		t.Run(v.title, func(t *testing.T) {
 			tokens := tnz.Tokenize(input)
 			var got []string
-			filter.PickUp(&tokens, func(t tokenizer.Token) bool {
+			filter.Keep(&tokens, func(t tokenizer.Token) bool {
 				for _, w := range v.wordList {
 					if w == t.Surface {
 						return true
@@ -62,7 +62,7 @@ func TestPickup(t *testing.T) {
 	}
 
 	t.Run("empty input test", func(t *testing.T) {
-		filter.PickUp(nil, func(t tokenizer.Token) bool {
+		filter.Keep(nil, func(t tokenizer.Token) bool {
 			return true
 		})
 	})
@@ -147,7 +147,7 @@ func Benchmark_TokenFilter_WordFilter(b *testing.B) {
 		}
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			filter.PickUp(&tokens, func(t tokenizer.Token) bool {
+			filter.Keep(&tokens, func(t tokenizer.Token) bool {
 				_, ok := words[t.Surface]
 				return ok
 			})
@@ -159,7 +159,7 @@ func Benchmark_TokenFilter_WordFilter(b *testing.B) {
 		filter := filter.NewWordFilter(words)
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			filter.PickUp(&tokens)
+			filter.Keep(&tokens)
 		}
 	})
 }

--- a/filter/pos.go
+++ b/filter/pos.go
@@ -29,8 +29,8 @@ func (f POSFilter) Drop(tokens *[]tokenizer.Token) {
 	f.apply(tokens, true)
 }
 
-// PickUp picks up a token if a filter matches token's POS.
-func (f POSFilter) PickUp(tokens *[]tokenizer.Token) {
+// Keep keeps a token if a filter matches token's POS.
+func (f POSFilter) Keep(tokens *[]tokenizer.Token) {
 	f.apply(tokens, false)
 }
 

--- a/filter/pos_test.go
+++ b/filter/pos_test.go
@@ -89,7 +89,7 @@ func TestPOSFilter_Match(t *testing.T) {
 	}
 }
 
-func TestPOSFilter_PickUp(t *testing.T) {
+func TestPOSFilter_Keep(t *testing.T) {
 	d, err := dict.LoadDictFile(testDictPath)
 	if err != nil {
 		panic(err)
@@ -127,7 +127,7 @@ func TestPOSFilter_PickUp(t *testing.T) {
 			tokens := tnz.Tokenize(input)
 			filter := filter.NewPOSFilter(v.featuresList...)
 			var got []string
-			filter.PickUp(&tokens)
+			filter.Keep(&tokens)
 			for _, token := range tokens {
 				got = append(got, token.Surface)
 			}
@@ -139,7 +139,7 @@ func TestPOSFilter_PickUp(t *testing.T) {
 
 	t.Run("empty input test", func(t *testing.T) {
 		filter := filter.NewPOSFilter(nil)
-		filter.PickUp(nil)
+		filter.Keep(nil)
 	})
 }
 

--- a/filter/word.go
+++ b/filter/word.go
@@ -30,8 +30,8 @@ func (f WordFilter) Drop(tokens *[]tokenizer.Token) {
 	f.apply(tokens, true)
 }
 
-// PickUp picks up a token if a filter matches token's surface.
-func (f WordFilter) PickUp(tokens *[]tokenizer.Token) {
+// Keep keeps a token if a filter matches token's surface.
+func (f WordFilter) Keep(tokens *[]tokenizer.Token) {
 	f.apply(tokens, false)
 }
 

--- a/filter/word_test.go
+++ b/filter/word_test.go
@@ -57,7 +57,7 @@ func TestWordFilter_Match(t *testing.T) {
 	}
 }
 
-func TestWordFilter_PickUp(t *testing.T) {
+func TestWordFilter_Keep(t *testing.T) {
 	d, err := dict.LoadDictFile(testDictPath)
 	if err != nil {
 		panic(err)
@@ -93,7 +93,7 @@ func TestWordFilter_PickUp(t *testing.T) {
 			tokens := tnz.Tokenize(input)
 			filter := filter.NewWordFilter(v.wordList)
 			var got []string
-			filter.PickUp(&tokens)
+			filter.Keep(&tokens)
 			for _, token := range tokens {
 				got = append(got, token.Surface)
 			}
@@ -105,7 +105,7 @@ func TestWordFilter_PickUp(t *testing.T) {
 
 	t.Run("empty input test", func(t *testing.T) {
 		filter := filter.NewWordFilter(nil)
-		filter.PickUp(nil)
+		filter.Keep(nil)
 	})
 }
 


### PR DESCRIPTION
According to [Merriam-Webster](https://www.merriam-webster.com), _pick up_ is an antonym for [_drop_](https://www.merriam-webster.com/thesaurus/drop) in a sense of "to cause to fall intentionally or unintentionally" or "to go to a lower level especially abruptly." So, it's inappropriate.

In this filtering context, _keep_ might be a good option. Merriam-Webster also says [_drop_ is a near antonym for _keep_ in a sense of "to continue to have in one's possession or power."](https://www.merriam-webster.com/thesaurus/keep#verb)