### PR TITLE
feat issue #161 Automated Docker image for x86_64 and ARM architectures.

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - v2
-      - feat-docker-arm-compatible
 
 env:
   NAME_IMAGE: "${{ secrets.DOCKER_USERNAME }}/kagome"

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -1,0 +1,103 @@
+name: Build Docker Images of Kagome Docker Hub Release
+
+on:
+  push:
+    branches:
+      - v2
+      - feat-docker-arm-compatible
+
+env:
+  NAME_IMAGE: "${{ secrets.DOCKER_USERNAME }}/kagome"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      # Clone and checkout the repo. "fetch-depth" is needed in order to get the
+      # version tag information.
+      - name: Checkout the code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      # Install QEMU emulators for Buildx
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
+
+      # Install Buildx to build multi-arch docker images.
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          version: latest
+
+      # View available platforms
+      - name: Available platforms of Buildx
+        run: echo ${{ steps.buildx.outputs.platforms }}
+
+      # Login to Docker Hub. You need to set the below two secreat env variables
+      # in the repo's [Settings]-[Secrets] settings in advance:
+      #   DOCKER_USERNAME  ... Login user name of Docker Hub
+      #   DOCKER_PASSWORD  ... Access Token from https://hub.docker.com/settings/security
+      - name: Login to DockerHub
+        if: success() && github.event_name != 'pull_request'
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      # To make the "latest" tag work not only for x86_64(Intel/AMD) but with ARMs
+      # such as ARM v6, v7 and ARM64 architectures, we need a temporary workaround
+      # due to the bug of Docker. https://github.com/moby/moby/issues/37647
+      - name: Build the images
+        # Build images for each architecture and push them.
+        run: |
+            docker system prune -f -a && \
+            docker buildx build --push --tag ${{ env.NAME_IMAGE }}:arm32v6 --platform linux/arm/v6 --build-arg GOARCH=arm --build-arg GOARM=6 . && \
+            docker buildx build --push --tag ${{ env.NAME_IMAGE }}:arm32v7 --platform linux/arm/v7 --build-arg GOARCH=arm --build-arg GOARM=7 . && \
+            docker buildx build --push --tag ${{ env.NAME_IMAGE }}:arm64   --platform linux/arm64  --build-arg GOARCH=arm64 . && \
+            docker buildx build --push --tag ${{ env.NAME_IMAGE }}:amd64   --platform linux/amd64 .
+      - name: Pull back the images
+        # We need to pull back the built images to use the manifest which Docker
+        # Hub did attach.
+        run: |
+            docker system prune -f -a && \
+            docker pull ${{ env.NAME_IMAGE }}:arm32v6 && \
+            docker pull ${{ env.NAME_IMAGE }}:arm32v7 && \
+            docker pull ${{ env.NAME_IMAGE }}:arm64 && \
+            docker pull ${{ env.NAME_IMAGE }}:amd64
+      - name: Create latest manifest and push
+        # Merge all the manifests as one "latest" tag and rename the variant to
+        # let it be compatible with arm6l and 7l. Then push.
+        run: |
+            export DOCKER_CLI_EXPERIMENTAL=enabled && \
+            docker version && \
+            docker manifest create ${{ env.NAME_IMAGE }}:latest \
+                ${{ env.NAME_IMAGE }}:arm32v6 \
+                ${{ env.NAME_IMAGE }}:arm32v7 \
+                ${{ env.NAME_IMAGE }}:arm64 \
+                ${{ env.NAME_IMAGE }}:amd64 && \
+            docker manifest annotate ${{ env.NAME_IMAGE }}:latest ${{ env.NAME_IMAGE }}:arm32v6 --variant v6l && \
+            docker manifest annotate ${{ env.NAME_IMAGE }}:latest ${{ env.NAME_IMAGE }}:arm32v7 --variant v7l && \
+            docker manifest inspect ${{ env.NAME_IMAGE }}:latest && \
+            docker manifest push ${{ env.NAME_IMAGE }}:latest --purge
+      - name: Create current manifest and push
+        # Create manifest of current Kagome version with "vX.Y.Z" tag.
+        run: |
+            git_tag=$(git describe --tag) && \
+            version_curr=$(echo "${git_tag}" | grep -o -E "(v[0-9]+\.){1}[0-9]+(\.[0-9]+)?" | head -n1) && \
+            echo '- Removing latest image (prevent conflict)' && \
+            docker image rm -f ${{ env.NAME_IMAGE }}:latest && \
+            echo "- Creating manifest for Kagome version: ${version_curr}" && \
+            export DOCKER_CLI_EXPERIMENTAL=enabled && \
+            docker manifest create ${{ env.NAME_IMAGE }}:${version_curr} \
+                ${{ env.NAME_IMAGE }}:arm32v6 \
+                ${{ env.NAME_IMAGE }}:arm32v7 \
+                ${{ env.NAME_IMAGE }}:arm64 \
+                ${{ env.NAME_IMAGE }}:amd64 && \
+            docker manifest annotate ${{ env.NAME_IMAGE }}:${version_curr} ${{ env.NAME_IMAGE }}:arm32v6 --variant v6l && \
+            docker manifest annotate ${{ env.NAME_IMAGE }}:${version_curr} ${{ env.NAME_IMAGE }}:arm32v7 --variant v7l && \
+            docker manifest inspect ${{ env.NAME_IMAGE }}:${version_curr} && \
+            docker manifest push ${{ env.NAME_IMAGE }}:${version_curr} --purge


### PR DESCRIPTION
A fix to issue #161 

- .github/workflows/build-docker.yml
  - GitHub Actions' workflow to build Docker images and push to Docker Hub.
  - To make it work, **you need to add the below 2 secret variables in the repo's [Settings]-[Secrets] settings**.
    - DOCKER_USERNAME  ... Login user name of Docker Hub
    - DOCKER_PASSWORD  ... Access Token from https://hub.docker.com/settings/security
- Dockerfile
  - removed `CGO_ENABLED` and `-installsuffix`. Since Go 1.10, `CGO_ENABLED=0` and `-installsuffix cgo` are no longer required, so removed.
  - Also, `-a`(force rebuild) was removed as well. Since most of the packages are already prebuilt with CGO_ENABLED=0 out of the box. BTW the current go version of the GitHub Actions is go1.15.2.