### PR TITLE
CGO_ENABLED=0 is still required for static linking

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN \
   echo "- Current git tag: ${version_app}" && \
   echo "- Current Go version: $(go version)" && \
   echo "- Kagome version to be build:${version_app}" && \
-  GOOS=${GOOS} GOARCH=${GOARCH} GOARM=${GOARM} go build \
+  CGO_ENABLED=0 GOOS=${GOOS} GOARCH=${GOARCH} GOARM=${GOARM} go build \
     --ldflags "-w -s -extldflags \"-static\" -X 'main.version=${version_app}'" \
     -o /go/bin/kagome \
     /go/src/github.com/ikawaha/kagome/cmd/kagome && \


### PR DESCRIPTION
ikawaha/kagome で提供されるkagomeコマンドがdynamic linkに変わっていたものをstatic linkに戻すPRです。
#197 をみるに単に不要だから`CGO_ENABLED=0`を外したようですが、なんだかよくわからないけどとにかく出来上がったものはdynamic linkになっていて、とりあえず`CGO_ENABLED=0`を戻したらstatic linkになりました（※手元環境）。

[このあたり](https://christina04.hatenablog.com/entry/installsuffix-cgo-is-no-longer-required) が関係しているのかなと思っていますがよくわかりません。

※2 linux/amd64 環境ではうまくいきそうですが、他の環境でそもそもビルドされるのか、どのようなリンク形態でになるのかはわかっていません