### PR TITLE
Feat JSON option for tokenize command (issue #246)

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,8 +170,8 @@ EOS
 ```
 
 ```shellsession
-% # piped stdin
-echo "すもももももももものうち" | go run .
+% # piped standard input
+echo "すもももももももものうち" | kagome
 すもも  名詞,一般,*,*,*,*,すもも,スモモ,スモモ
 も      助詞,係助詞,*,*,*,*,も,モ,モ
 もも    名詞,一般,*,*,*,*,もも,モモ,モモ

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The dictionary/statistical models such as MeCab-IPADIC, UniDic (unidic-mecab) an
 
 |dict| source | package |
 |:---|:---|:---|
-|MeCab IPADIC| mecab-ipadic-2.7.0-20070801 | [github.com/ikawaha/kagome-dict/ipa](https://github.com/ikawaha/kagome-dict/tree/master/ipa)| 
+|MeCab IPADIC| mecab-ipadic-2.7.0-20070801 | [github.com/ikawaha/kagome-dict/ipa](https://github.com/ikawaha/kagome-dict/tree/master/ipa)|
 |UniDIC| unidic-mecab-2.1.2_src | [github.com/ikawaha/kagome-dict/uni](https://github.com/ikawaha/kagome-dict/tree/master/uni) |
 
 **Experimental Features**
@@ -131,26 +131,32 @@ The commands are:
    [tokenize] - command line tokenize (*default)
    server - run tokenize server
    lattice - lattice viewer
+   sentence - tiny sentence splitter
    version - show version
 
-tokenize [-file input_file] [-dict dic_file] [-userdict userdic_file] [-sysdict (ipa|uni)] [-simple false] [-mode (normal|search|extended)]
+tokenize [-file input_file] [-dict dic_file] [-userdict userdic_file] [-sysdict (ipa|uni)] [-simple false] [-mode (normal|search|extended)] [-split] [-json]
   -dict string
-    	dict
+        dict
   -file string
-    	input file
+        input file
+  -json
+        outputs in JSON format
   -mode string
-    	tokenize mode (normal|search|extended) (default "normal")
+        tokenize mode (normal|search|extended) (default "normal")
   -simple
-    	display abbreviated dictionary contents
+        display abbreviated dictionary contents
+  -split
+        use tiny sentence splitter
   -sysdict string
-    	system dict type (ipa|uni) (default "ipa")
+        system dict type (ipa|uni) (default "ipa")
   -udict string
-    	user dict
+        user dict
 ```
 
 ### Tokenize command
 
 ```shellsession
+% # interactive mode
 % kagome
 すもももももももものうち
 すもも	名詞,一般,*,*,*,*,すもも,スモモ,スモモ
@@ -163,6 +169,64 @@ tokenize [-file input_file] [-dict dic_file] [-userdict userdic_file] [-sysdict 
 EOS
 ```
 
+```shellsession
+% # piped stdin
+echo "すもももももももものうち" | go run .
+すもも  名詞,一般,*,*,*,*,すもも,スモモ,スモモ
+も      助詞,係助詞,*,*,*,*,も,モ,モ
+もも    名詞,一般,*,*,*,*,もも,モモ,モモ
+も      助詞,係助詞,*,*,*,*,も,モ,モ
+もも    名詞,一般,*,*,*,*,もも,モモ,モモ
+の      助詞,連体化,*,*,*,*,の,ノ,ノ
+うち    名詞,非自立,副詞可能,*,*,*,うち,ウチ,ウチ
+EOS
+```
+
+```shellsession
+% # JSON output
+% echo "猫" | kagome -json | jq .
+[
+  {
+    "id": 286994,
+    "start": 0,
+    "end": 1,
+    "surface": "猫",
+    "class": "KNOWN",
+    "pos": [
+      "名詞",
+      "一般",
+      "*",
+      "*"
+    ],
+    "base_form": "猫",
+    "reading": "ネコ",
+    "pronunciation": "ネコ",
+    "features": [
+      "名詞",
+      "一般",
+      "*",
+      "*",
+      "*",
+      "*",
+      "猫",
+      "ネコ",
+      "ネコ"
+    ]
+  }
+]
+```
+
+```shellsession
+echo "私ははにわよわわわんわん" | kagome -json | jq -r '.[].pronunciation'
+ワタシ
+ワ
+ハニワ
+ヨ
+ワ
+ワ
+ワンワン
+```
+
 ### Server command
 
 **API**
@@ -171,15 +235,15 @@ Start a server and try to access the "/tokenize" endpoint.
 
 ```shellsession
 % kagome server &
-% curl -XPUT localhost:6060/tokenize -d'{"sentence":"すもももももももものうち", "mode":"normal"}' | jq . 
+% curl -XPUT localhost:6060/tokenize -d'{"sentence":"すもももももももものうち", "mode":"normal"}' | jq .
 ```
 
-**Web App** 
+**Web App**
 
 [![demo](https://img.shields.io/badge/demo-heroku_deployed-blue.svg)](https://kagome.herokuapp.com/)
 
 
-Start a server and access `http://localhost:6060`. 
+Start a server and access `http://localhost:6060`.
 (To draw a lattice, demo application uses graphviz . You need graphviz installed.)
 
 ```shellsession
@@ -204,7 +268,7 @@ A debug tool of tokenize process outputs a lattice in graphviz dot format.
 # Building to WebAssembly
 
 You can see how kagome wasm works in [demo site.](http://ikawaha.github.io/kagome/)
-The source code can be found in `./sample/wasm`. 
+The source code can be found in `./sample/wasm`.
 
 # Licence
 

--- a/cmd/tokenize/PrintScannedTokens.go
+++ b/cmd/tokenize/PrintScannedTokens.go
@@ -41,6 +41,8 @@ func ParseTokenToJSON(tok tokenizer.Token) ([]byte, error) {
 	return json.Marshal(j)
 }
 
+// PrintTokensAsDefault prints the tokenized text in the default format.
+// The default format is: [Surface]\t[Features in CSV]\n
 func PrintTokensAsDefault(s *bufio.Scanner, t *tokenizer.Tokenizer, mode tokenizer.TokenizeMode) error {
 	for s.Scan() {
 		sen := s.Text()
@@ -60,10 +62,11 @@ func PrintTokensAsDefault(s *bufio.Scanner, t *tokenizer.Tokenizer, mode tokeniz
 	return s.Err()
 }
 
+// PrintTokensInJSON prints the tokenized text in JSON format.
 func PrintTokensInJSON(s *bufio.Scanner, t *tokenizer.Tokenizer, mode tokenizer.TokenizeMode) (err error) {
 	var buff []byte
 
-	fmt.Println("[") // Begin bracket
+	fmt.Println("[") // Begin array bracket
 
 	for s.Scan() {
 		sen := s.Text()
@@ -75,7 +78,7 @@ func PrintTokensInJSON(s *bufio.Scanner, t *tokenizer.Tokenizer, mode tokenizer.
 			}
 
 			if len(buff) > 0 {
-				fmt.Printf("%s,\n", buff) // Print with comma
+				fmt.Printf("%s,\n", buff) // Print array element (JSON with comma)
 			}
 
 			if buff, err = ParseTokenToJSON(tok); err != nil {
@@ -85,18 +88,17 @@ func PrintTokensInJSON(s *bufio.Scanner, t *tokenizer.Tokenizer, mode tokenizer.
 	}
 
 	if s.Err() == nil {
-		fmt.Printf("%s\n", buff) // Spit the last buffer w/no comma
-		fmt.Println("]")         // End bracket
+		fmt.Printf("%s\n", buff) // Spit out the last buffer without comma to close the array
+		fmt.Println("]")         // End array bracket
 	}
 
 	return s.Err()
-
 }
 
-func PrintScannedTokens(s *bufio.Scanner, t *tokenizer.Tokenizer, mode tokenizer.TokenizeMode, jsonOut bool) error {
-	if !jsonOut {
-		return PrintTokensAsDefault(s, t, mode)
+func PrintScannedTokens(s *bufio.Scanner, t *tokenizer.Tokenizer, mode tokenizer.TokenizeMode, opt *option) error {
+	if opt.json {
+		return PrintTokensInJSON(s, t, mode)
 	}
 
-	return PrintTokensInJSON(s, t, mode)
+	return PrintTokensAsDefault(s, t, mode)
 }

--- a/cmd/tokenize/PrintScannedTokens.go
+++ b/cmd/tokenize/PrintScannedTokens.go
@@ -1,0 +1,102 @@
+package tokenize
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/ikawaha/kagome/v2/tokenizer"
+)
+
+type TokenedJSON struct {
+	ID            int      `json:"id"`
+	Start         int      `json:"start"`
+	End           int      `json:"end"`
+	Surface       string   `json:"surface"`
+	Class         string   `json:"class"`
+	POS           []string `json:"pos"`
+	BaseForm      string   `json:"base_form"`
+	Reading       string   `json:"reading"`
+	Pronunciation string   `json:"pronunciation"`
+	Features      []string `json:"features"`
+}
+
+// ParseTokenToJSON parses the token to JSON in the same format as the server mode response does.
+func ParseTokenToJSON(tok tokenizer.Token) ([]byte, error) {
+	j := TokenedJSON{
+		ID:       tok.ID,
+		Start:    tok.Start,
+		End:      tok.End,
+		Surface:  tok.Surface,
+		Class:    fmt.Sprintf("%v", tok.Class),
+		POS:      tok.POS(),
+		Features: tok.Features(),
+	}
+
+	j.BaseForm, _ = tok.BaseForm()
+	j.Reading, _ = tok.Reading()
+	j.Pronunciation, _ = tok.Pronunciation()
+
+	return json.Marshal(j)
+}
+
+func PrintTokensAsDefault(s *bufio.Scanner, t *tokenizer.Tokenizer, mode tokenizer.TokenizeMode) error {
+	for s.Scan() {
+		sen := s.Text()
+		tokens := t.Analyze(sen, mode)
+
+		for i, size := 1, len(tokens); i < size; i++ {
+			tok := tokens[i]
+			c := tok.Features()
+			if tok.Class == tokenizer.DUMMY {
+				fmt.Printf("%s\n", tok.Surface)
+			} else {
+				fmt.Printf("%s\t%v\n", tok.Surface, strings.Join(c, ","))
+			}
+		}
+	}
+
+	return s.Err()
+}
+
+func PrintTokensInJSON(s *bufio.Scanner, t *tokenizer.Tokenizer, mode tokenizer.TokenizeMode) (err error) {
+	var buff []byte
+
+	fmt.Println("[") // Begin bracket
+
+	for s.Scan() {
+		sen := s.Text()
+		tokens := t.Analyze(sen, mode)
+
+		for _, tok := range tokens {
+			if tok.ID == tokenizer.BosEosID {
+				continue
+			}
+
+			if len(buff) > 0 {
+				fmt.Printf("%s,\n", buff) // Print with comma
+			}
+
+			if buff, err = ParseTokenToJSON(tok); err != nil {
+				return err
+			}
+		}
+	}
+
+	if s.Err() == nil {
+		fmt.Printf("%s\n", buff) // Spit the last buffer w/no comma
+		fmt.Println("]")         // End bracket
+	}
+
+	return s.Err()
+
+}
+
+func PrintScannedTokens(s *bufio.Scanner, t *tokenizer.Tokenizer, mode tokenizer.TokenizeMode, jsonOut bool) error {
+	if !jsonOut {
+		return PrintTokensAsDefault(s, t, mode)
+	}
+
+	return PrintTokensInJSON(s, t, mode)
+}

--- a/cmd/tokenize/PrintScannedTokens.go
+++ b/cmd/tokenize/PrintScannedTokens.go
@@ -9,7 +9,8 @@ import (
 	"github.com/ikawaha/kagome/v2/tokenizer"
 )
 
-type TokenedJSON struct {
+// tokenedJSON is a struct to output the tokens as JSON format.
+type tokenedJSON struct {
 	ID            int      `json:"id"`
 	Start         int      `json:"start"`
 	End           int      `json:"end"`
@@ -22,15 +23,19 @@ type TokenedJSON struct {
 	Features      []string `json:"features"`
 }
 
-// Variables for dependency injection or mocking for testing
+// Variable for dependency injection and/or mocking for testing
 var (
-	JsonMarshal = json.Marshal
+	JSONMarshal = json.Marshal
 	FmtPrintF   = fmt.Printf
 )
 
+func fmtPrintF(format string, a ...interface{}) {
+	_, _ = FmtPrintF(format, a...)
+}
+
 // parseTokenToJSON parses the token to JSON in the same format as the server mode response does.
 func parseTokenToJSON(tok tokenizer.Token) ([]byte, error) {
-	j := TokenedJSON{
+	j := tokenedJSON{
 		ID:       tok.ID,
 		Start:    tok.Start,
 		End:      tok.End,
@@ -44,7 +49,7 @@ func parseTokenToJSON(tok tokenizer.Token) ([]byte, error) {
 	j.Reading, _ = tok.Reading()
 	j.Pronunciation, _ = tok.Pronunciation()
 
-	return JsonMarshal(j)
+	return JSONMarshal(j)
 }
 
 // printTokensAsDefault prints the tokenized text in the default format.
@@ -58,9 +63,9 @@ func printTokensAsDefault(s *bufio.Scanner, t *tokenizer.Tokenizer, mode tokeniz
 			tok := tokens[i]
 			c := tok.Features()
 			if tok.Class == tokenizer.DUMMY {
-				FmtPrintF("%s\n", tok.Surface)
+				fmtPrintF("%s\n", tok.Surface)
 			} else {
-				FmtPrintF("%s\t%v\n", tok.Surface, strings.Join(c, ","))
+				fmtPrintF("%s\t%v\n", tok.Surface, strings.Join(c, ","))
 			}
 		}
 	}
@@ -72,7 +77,7 @@ func printTokensAsDefault(s *bufio.Scanner, t *tokenizer.Tokenizer, mode tokeniz
 func printTokensInJSON(s *bufio.Scanner, t *tokenizer.Tokenizer, mode tokenizer.TokenizeMode) (err error) {
 	var buff []byte
 
-	FmtPrintF("[\n") // Begin array bracket
+	fmtPrintF("[\n") // Begin array bracket
 
 	for s.Scan() {
 		sen := s.Text()
@@ -84,7 +89,7 @@ func printTokensInJSON(s *bufio.Scanner, t *tokenizer.Tokenizer, mode tokenizer.
 			}
 
 			if len(buff) > 0 {
-				FmtPrintF("%s,\n", buff) // Print array element (JSON with comma)
+				fmtPrintF("%s,\n", buff) // Print array element (JSON with comma)
 			}
 
 			if buff, err = parseTokenToJSON(tok); err != nil {
@@ -94,13 +99,14 @@ func printTokensInJSON(s *bufio.Scanner, t *tokenizer.Tokenizer, mode tokenizer.
 	}
 
 	if s.Err() == nil {
-		FmtPrintF("%s\n", buff) // Spit out the last buffer without comma to close the array
-		FmtPrintF("]\n")        // End array bracket
+		fmtPrintF("%s\n", buff) // Spit out the last buffer without comma to close the array
+		fmtPrintF("]\n")        // End array bracket
 	}
 
 	return s.Err()
 }
 
+// PrintScannedTokens scans and analizes to tokenize the input and print out.
 func PrintScannedTokens(s *bufio.Scanner, t *tokenizer.Tokenizer, mode tokenizer.TokenizeMode, opt *option) error {
 	if opt.json {
 		return printTokensInJSON(s, t, mode)

--- a/cmd/tokenize/PrintScannedTokens_test.go
+++ b/cmd/tokenize/PrintScannedTokens_test.go
@@ -146,7 +146,7 @@ func mockStdin(t *testing.T, dummyInput string) (funcDefer func(), err error) {
 	t.Helper()
 
 	oldOsStdin := os.Stdin
-	tmpfile, err := ioutil.TempFile(t.TempDir(), t.Name())
+	tmpfile, err := ioutil.TempFile(os.TempDir(), t.Name())
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/tokenize/PrintScannedTokens_test.go
+++ b/cmd/tokenize/PrintScannedTokens_test.go
@@ -1,0 +1,123 @@
+package tokenize_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/ikawaha/kagome/v2/cmd/tokenize"
+)
+
+func TestPrintScannedTokens_Default(t *testing.T) {
+	userInput := "私"
+	userArgs := []string{}
+
+	// Mock STDIN
+	if funcDefer, err := mockStdin(t, userInput); err != nil {
+		t.Fatal(err)
+	} else {
+		defer funcDefer()
+	}
+
+	// Caputre output
+	capturedSTDOUT := ""
+	funcDefer := setCapturer(t, &capturedSTDOUT)
+
+	defer funcDefer()
+
+	// Run
+	tokenize.Run(userArgs)
+
+	// Assert
+	expect := "私	名詞,代名詞,一般,*,*,*,私,ワタシ,ワタシ\nEOS\n"
+	actual := capturedSTDOUT
+
+	if expect != actual {
+		t.Errorf("Expect: %v\nActual: %v", expect, actual)
+	}
+}
+
+func TestPrintScannedTokens_JSON(t *testing.T) {
+	userInput := "私"
+	userArgs := []string{"-json"}
+
+	if funcDefer, err := mockStdin(t, userInput); err != nil {
+		t.Fatal(err)
+	} else {
+		defer funcDefer()
+	}
+
+	// Caputre output
+	capturedSTDOUT := ""
+	funcDefer := setCapturer(t, &capturedSTDOUT)
+
+	defer funcDefer()
+
+	// Run
+	tokenize.Run(userArgs)
+
+	// Assert
+	expect := "[\n{\"id\":304999,\"start\":0,\"end\":1,\"surface\":\"私\"," +
+		"\"class\":\"KNOWN\",\"pos\":[\"名詞\",\"代名詞\",\"一般\",\"*\"]," +
+		"\"base_form\":\"私\",\"reading\":\"ワタシ\",\"pronunciation\":\"ワタシ\"," +
+		"\"features\":[\"名詞\",\"代名詞\",\"一般\",\"*\",\"*\",\"*\",\"私\",\"ワタシ\"," +
+		"\"ワタシ\"]}\n]\n"
+	actual := capturedSTDOUT
+
+	if expect != actual {
+		t.Errorf("Expect: %v\nActual: %v", expect, actual)
+	}
+}
+
+// Helper functions
+
+// setCapturer is a helper function that captures the output of tokenize.FmtPrintF to capturedSTDOUT.
+func setCapturer(t *testing.T, capturedSTDOUT *string) (funcDefer func()) {
+	t.Helper()
+
+	// Backup and set mock function
+	oldFmtPrintF := tokenize.FmtPrintF
+	tokenize.FmtPrintF = func(format string, a ...interface{}) (n int, err error) {
+		*capturedSTDOUT += fmt.Sprintf(format, a...)
+
+		return
+	}
+
+	// Return restore function
+	return func() {
+		tokenize.FmtPrintF = oldFmtPrintF
+	}
+}
+
+// mockStdin is a helper function that lets the test pretend dummyInput as "os.Stdin" input.
+// It will return a function for `defer` to clean up after the test.
+func mockStdin(t *testing.T, dummyInput string) (funcDefer func(), err error) {
+	t.Helper()
+
+	oldOsStdin := os.Stdin
+	tmpfile, err := ioutil.TempFile(t.TempDir(), t.Name())
+
+	if err != nil {
+		return nil, err
+	}
+
+	content := []byte(dummyInput)
+
+	if _, err := tmpfile.Write(content); err != nil {
+		return nil, err
+	}
+
+	if _, err := tmpfile.Seek(0, 0); err != nil {
+		return nil, err
+	}
+
+	// Set stdin to the temp file
+	os.Stdin = tmpfile
+
+	return func() {
+		// clean up
+		os.Stdin = oldOsStdin
+		os.Remove(tmpfile.Name())
+	}, nil
+}


### PR DESCRIPTION
Implementation of issue #246, add `-json` option flag for `tokenize` command.

- [x] Flag option `-json` for tokenize cmd (`cmd/tokenize/cmd.go`)
- [x] Print out results when `-json` flag is up (`cmd/tokenize/PrintScannedTokens.go`)
- [x] Tests (`cmd/tokenize/PrintScannedTokens_test.go`)
- [x] Update documentation (`README.md`)