### PR TITLE
update: fix page number and refers original sample code

### DIFF
--- a/sample/_example/db_search/main.go
+++ b/sample/_example/db_search/main.go
@@ -29,6 +29,7 @@ This example is taken in part from the following book for reference.
   - Published: 2023/3/9 (技術評論社)
   - ISBN: 4297134195 / 978-4297134198
   - ASIN: B0BVZCJQ4F / https://amazon.co.jp/dp/4297134195
+  - Original sample code: https://github.com/mattn/aozora-search
 */
 package main
 

--- a/sample/_example/db_search/main.go
+++ b/sample/_example/db_search/main.go
@@ -24,7 +24,7 @@ Acknowledgements:
 
 This example is taken in part from the following book for reference.
 
-- p.203, 9.2 "データーベース登録プログラム", "Go言語プログラミングエッセンス エンジニア選書"
+- p.204, 9.2 "データーベース登録プログラム", "Go言語プログラミングエッセンス エンジニア選書"
   - Written by: Mattn
   - Published: 2023/3/9 (技術評論社)
   - ISBN: 4297134195 / 978-4297134198

--- a/sample/_example/db_search/main.go
+++ b/sample/_example/db_search/main.go
@@ -24,7 +24,7 @@ Acknowledgements:
 
 This example is taken in part from the following book for reference.
 
-- p.372, 9.2 "データーベース登録プログラム", "Go言語プログラミングエッセンス エンジニア選書"
+- p.203, 9.2 "データーベース登録プログラム", "Go言語プログラミングエッセンス エンジニア選書"
   - Written by: Mattn
   - Published: 2023/3/9 (技術評論社)
   - ISBN: 4297134195 / 978-4297134198


### PR DESCRIPTION
## What

- Fix page number. I have this book and I suppose the page number is 204.
- refers to the original sample code. https://github.com/mattn/aozora-search


## Why

It is very interesting! Thank you for a good example

https://github.com/ikawaha/kagome/blob/v2/sample/_example/db_search/main.go

I found a some improvement points.
