### PR TITLE
fix: release badge failure (false positive status)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![GoDev](https://pkg.go.dev/badge/github.com/ikawaha/kagome/v2)](https://pkg.go.dev/github.com/ikawaha/kagome/v2)
 [![Go](https://github.com/ikawaha/kagome/workflows/Go/badge.svg)](https://github.com/ikawaha/kagome/actions?query=workflow%3AGo)
-[![Release](https://github.com/ikawaha/kagome/actions/workflows/release.yml/badge.svg)](https://github.com/ikawaha/kagome/actions/workflows/release.yml)
+[![Release](https://github.com/ikawaha/kagome/actions/workflows/release.yml/badge.svg?branch=)](https://github.com/ikawaha/kagome/actions/workflows/release.yml)
 [![Coverage Status](https://coveralls.io/repos/github/ikawaha/kagome/badge.svg?branch=v2)](https://coveralls.io/github/ikawaha/kagome?branch=v2)
 [![Docker Pulls](https://img.shields.io/docker/pulls/ikawaha/kagome.svg?style)](https://hub.docker.com/r/ikawaha/kagome/)
 


### PR DESCRIPTION
盆jour! This PR fixes the false positive badge status that keeps failing.

- Before: [![Release](https://github.com/ikawaha/kagome/actions/workflows/release.yml/badge.svg)](https://github.com/ikawaha/kagome/actions/workflows/release.yml)
- After: [![Release](https://github.com/ikawaha/kagome/actions/workflows/release.yml/badge.svg?branch=)](https://github.com/ikawaha/kagome/actions/workflows/release.yml)
- Ref: https://github.com/actions/starter-workflows/issues/1525#issuecomment-1514559519