### PR TITLE
chore: Update kagome-dict and fix Go version

### DIFF
--- a/cmd/lattice/cmd_test.go
+++ b/cmd/lattice/cmd_test.go
@@ -2,6 +2,7 @@ package lattice
 
 import (
 	"bytes"
+	"context"
 	"flag"
 	"os"
 	"strings"
@@ -100,7 +101,7 @@ func TestRun(t *testing.T) {
 	}()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := Run(t.Context(), tt.args); (err != nil) != tt.wantErr {
+			if err := Run(context.Background(), tt.args); (err != nil) != tt.wantErr {
 				t.Errorf("Run() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
@@ -159,7 +160,7 @@ func Test_command(t *testing.T) {
 				Stdout = os.Stdout
 				Stderr = os.Stderr
 			}()
-			if err := command(t.Context(), tt.args); (err != nil) != tt.wantErr {
+			if err := command(context.Background(), tt.args); (err != nil) != tt.wantErr {
 				t.Errorf("command() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			if tt.wantErr {

--- a/cmd/sentence/cmd_test.go
+++ b/cmd/sentence/cmd_test.go
@@ -2,6 +2,7 @@ package sentence
 
 import (
 	"bytes"
+	"context"
 	"flag"
 	"os"
 	"testing"
@@ -72,7 +73,7 @@ func TestRun(t *testing.T) {
 	}()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := Run(t.Context(), tt.args); (err != nil) != tt.wantErr {
+			if err := Run(context.Background(), tt.args); (err != nil) != tt.wantErr {
 				t.Errorf("Run() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
@@ -120,7 +121,7 @@ func Test_command(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var b bytes.Buffer
-			if err := command(t.Context(), &b, tt.args); (err != nil) != tt.wantErr {
+			if err := command(context.Background(), &b, tt.args); (err != nil) != tt.wantErr {
 				t.Errorf("command() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			if tt.want != "" {

--- a/cmd/server/cmd_test.go
+++ b/cmd/server/cmd_test.go
@@ -86,7 +86,7 @@ func TestRun(t *testing.T) {
 	}()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+			ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 			defer cancel()
 			if err := Run(ctx, tt.args); (err != nil) != tt.wantErr {
 				t.Errorf("Run() error = %v, wantErr %v", err, tt.wantErr)
@@ -139,7 +139,7 @@ func Test_command(t *testing.T) {
 	}()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+			ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 			defer cancel()
 			if err := command(ctx, tt.opt); (err != nil) != tt.wantErr {
 				t.Errorf("command() error = %v, wantErr %v", err, tt.wantErr)

--- a/cmd/server/demo_test.go
+++ b/cmd/server/demo_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -93,7 +94,7 @@ func TestTokenizeDemoHandler_analyzeGraph(t *testing.T) {
 		t.Fatalf("unexpected error, %v", err)
 	}
 	handler := TokenizeDemoHandler{tokenizer: tnz}
-	records, svg, err := handler.analyzeGraph(t.Context(), "ねこです", tokenizer.Normal)
+	records, svg, err := handler.analyzeGraph(context.Background(), "ねこです", tokenizer.Normal)
 	if err != nil {
 		t.Fatalf("unexpected error, analyzeGraph() failed, %v", err)
 	}

--- a/cmd/tokenize/cmd_test.go
+++ b/cmd/tokenize/cmd_test.go
@@ -2,6 +2,7 @@ package tokenize
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -39,7 +40,7 @@ func TestCommand_NormalOutput(t *testing.T) {
 		Stdout = stdout
 	}()
 
-	if err := command(t.Context(), &option{
+	if err := command(context.Background(), &option{
 		dict: "../../testdata/ipa.dict",
 	}); err != nil {
 		t.Errorf("unexpected error, command failed, %v", err)
@@ -88,7 +89,7 @@ func TestCommand_JSONOutput(t *testing.T) {
 	}()
 
 	// test
-	if err := command(t.Context(), &option{
+	if err := command(context.Background(), &option{
 		dict: "../../testdata/ipa.dict",
 		json: true,
 	}); err != nil {
@@ -147,7 +148,7 @@ func TestCommand_JSONOutput_issue249(t *testing.T) {
 	}()
 
 	// test
-	if err := command(t.Context(), &option{
+	if err := command(context.Background(), &option{
 		dict: "../../testdata/ipa.dict",
 		json: true,
 	}); err != nil {
@@ -272,7 +273,7 @@ func TestRun(t *testing.T) {
 	}()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := Run(t.Context(), tt.args); (err != nil) != tt.wantErr {
+			if err := Run(context.Background(), tt.args); (err != nil) != tt.wantErr {
 				t.Errorf("Run() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/filter/filter_test.go
+++ b/filter/filter_test.go
@@ -142,11 +142,11 @@ func Benchmark_TokenFilter_WordFilter(b *testing.B) {
 		tokens := tnz.Tokenize(input)
 		words := map[string]struct{}{
 			"人魚": {},
-			"南":  {},
-			"の":  {},
+			"南":   {},
+			"の":   {},
 		}
 		b.ResetTimer()
-		for b.Loop() {
+		for i := 0; i < b.N; i++ {
 			filter.Keep(&tokens, func(t tokenizer.Token) bool {
 				_, ok := words[t.Surface]
 				return ok
@@ -158,7 +158,7 @@ func Benchmark_TokenFilter_WordFilter(b *testing.B) {
 		words := []string{"人魚", "南", "の"}
 		fl := filter.NewWordFilter(words)
 		b.ResetTimer()
-		for b.Loop() {
+		for i := 0; i < b.N; i++ {
 			fl.Keep(&tokens)
 		}
 	})

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,9 @@
 module github.com/ikawaha/kagome/v2
 
-go 1.24.1
+go 1.23.0
 
 require (
-	github.com/ikawaha/kagome-dict v1.1.2
-	github.com/ikawaha/kagome-dict/ipa v1.2.1
-	github.com/ikawaha/kagome-dict/uni v1.2.1
+	github.com/ikawaha/kagome-dict v1.1.6
+	github.com/ikawaha/kagome-dict/ipa v1.2.5
+	github.com/ikawaha/kagome-dict/uni v1.2.5
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
-github.com/ikawaha/kagome-dict v1.1.2 h1:VJxjsNPl/dzCd2022Je6KLHlSBXJJ4v6wzMBaK65SGU=
-github.com/ikawaha/kagome-dict v1.1.2/go.mod h1:vCezTsAry4MpUl2n2NUfE1CG3meQlxulWfglT7pf1gw=
-github.com/ikawaha/kagome-dict/ipa v1.2.1 h1:+pPV8tH9Wz699AnxvYu7OGYUTfgcDSs3OJW0VuYrUNM=
-github.com/ikawaha/kagome-dict/ipa v1.2.1/go.mod h1:AjHGD0cctM9lnSS6SKqeTw0DaI2vTRVuTkFy1WGw6No=
-github.com/ikawaha/kagome-dict/uni v1.2.1 h1:hIgle96rqyfgHxKRhOzCtGrXvRwsGgD6Rel28keDZIM=
-github.com/ikawaha/kagome-dict/uni v1.2.1/go.mod h1:d7msFVR3izhein5HDlytpQn+4VRPyrHSmGz/o/RekGs=
+github.com/ikawaha/kagome-dict v1.1.6 h1:bpMDkXEbHsgh/gdqNMpASM5EDd/jpRtzm2AFJTGP6C4=
+github.com/ikawaha/kagome-dict v1.1.6/go.mod h1:kVQBTitXg2pqmQUMFqGOw60e14zahWKyEyuZW2n7Yus=
+github.com/ikawaha/kagome-dict/ipa v1.2.5 h1:uX9D/T7xNpx1nleDU6SSbpaYHgiAhRs9IIEkcWu9XLQ=
+github.com/ikawaha/kagome-dict/ipa v1.2.5/go.mod h1:mfrhW/dynf56fNLSD4fyC29wQsEffWJj7trEJjSZz5Q=
+github.com/ikawaha/kagome-dict/uni v1.2.5 h1:YlzuB1CG0HkawuX0eRIjDgoazsT89nYd4nXnQyDyIlU=
+github.com/ikawaha/kagome-dict/uni v1.2.5/go.mod h1:1UYPVH+GZ5NYiYLfKQG57v3gLbzdxLP5eYZ9sLlaI/M=

--- a/tokenizer/tokenizer_test.go
+++ b/tokenizer/tokenizer_test.go
@@ -423,7 +423,7 @@ func BenchmarkAnalyzeNormal(b *testing.B) {
 	}
 
 	b.ResetTimer()
-	for b.Loop() {
+	for i := 0; i < b.N; i++ {
 		tnz.Analyze(benchSampleText, Normal)
 	}
 }
@@ -439,7 +439,7 @@ func BenchmarkAnalyzeSearch(b *testing.B) {
 	}
 
 	b.ResetTimer()
-	for b.Loop() {
+	for i := 0; i < b.N; i++ {
 		tnz.Analyze(benchSampleText, Search)
 	}
 }
@@ -455,7 +455,7 @@ func BenchmarkAnalyzeExtended(b *testing.B) {
 	}
 
 	b.ResetTimer()
-	for b.Loop() {
+	for i := 0; i < b.N; i++ {
 		tnz.Analyze(benchSampleText, Extended)
 	}
 }
@@ -472,7 +472,7 @@ func BenchmarkTooLongUnknownToken(b *testing.B) {
 	}
 
 	b.ResetTimer()
-	for b.Loop() {
+	for i := 0; i < b.N; i++ {
 		tnz.Tokenize(input)
 	}
 }


### PR DESCRIPTION
issue: https://github.com/ikawaha/kagome-dict/issues/66

Fix the Go version to v1.23.0 and made minor adjustments, but there are no changes in behavior.
* Fix Go version to v1.23.0.
* Update kagome-dict to v1.1.6, ipa/v1.2.5 and uni/v1.2.5.
* Replace b.Loop() with for loop for Go 1.23 support.
* Replace t.Context() with context.Background() for Go 1.23 support.
