### PR TITLE
fix: #367 Update and refactor README.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist
 *.sqlite
 dict/mecab-ipadic-2.7.0-20070801
 dict/unidic-mecab-2.1.2_src
+go.work.sum

--- a/README.md
+++ b/README.md
@@ -6,49 +6,91 @@
 
 # Kagome v2
 
-Kagome is an open source Japanese morphological analyzer written in pure golang.
-
-The dictionary/statistical models such as MeCab-IPADIC, UniDic (unidic-mecab) and so on, are able to be embedded in binaries.
+Kagome is an open source Japanese morphological analyzer written in pure Go. It can tokenize Japanese text into words and analyze parts of speech, with dictionaries embedded in the binary for easy deployment.
 
 > [!NOTE]
-> **Improvements from [v1](https://github.com/ikawaha/kagome/tree/master)**
+> **Key features** (Improvements from [v1](https://github.com/ikawaha/kagome/tree/master)):
 >
-> * Dictionaries are maintained in a separate repository, and only the dictionaries you need are embedded in the binary.
-> * Brushed up and added several APIs.
+> * Self-contained binaries with embedded dictionaries (MeCab-IPADIC, UniDic)
+> * Multiple segmentation modes for different use cases
+> * RESTful API server mode for production use
+> * WebAssembly support for browser environments
 
-## Dictionaries
+## Index
 
-|dict| source | package |
-|:---|:---|:---|
-|MeCab IPADIC| mecab-ipadic-2.7.0-20070801 | [github.com/ikawaha/kagome-dict/ipa](https://github.com/ikawaha/kagome-dict/tree/master/ipa)|
-|UniDIC| unidic-mecab-2.1.2_src | [github.com/ikawaha/kagome-dict/uni](https://github.com/ikawaha/kagome-dict/tree/master/uni) |
+* [Basic Usage](#basic-usage)
+  * [Command line](#command-line)
+  * [As a Go library](#as-a-go-library)
+* [Install](#install)
+* [Commands](#commands)
+  * [Tokenize command](#tokenize-command)
+  * [Server command](#server-command)
+    * [RESTful API](#restful-api)
+    * [Web App](#web-app)
+  * [Lattice command](#lattice-command)
+  * [Sentence command](#sentence-command)
+* [Dictionaries](#dictionaries)
+* [Segmentation modes](#segmentation-modes)
+* [Docker](#docker)
+* [WebAssembly](#webassembly)
+* [Reference](#reference)
+* [License](#license)
 
-> [!NOTE]
-> IPADIC is MeCab's so-called "standard dictionary" and is characterized by its ability to split morphological units more intuitively than UniDIC. In contrast, UniDIC breaks phrases into smaller example sentence units to create metadata for full-text search. For more details, see the [wiki](https://github.com/ikawaha/kagome/wiki/About-the-dictionary).
+## Basic Usage
 
-* Experimental Features
+### Command line
 
-  |dict|source|package|
-  |:---|:---|:---|
-  |mecab-ipadic-NEologd|mecab-ipadic-neologd| [github.com/ikawaha/kagome-ipa-neologd](https://github.com/ikawaha/kagome-dict-ipa-neologd)|
-  |Korean MeCab|mecab-ko-dic-2.1.1-20180720 | [github.com/ikawaha/kagome-dict-ko](https://github.com/ikawaha/kagome-dict-ko)|
+```shellsession
+% kagome -h
+Japanese Morphological Analyzer -- github.com/ikawaha/kagome/v2
+usage: kagome <command>
+The commands are:
+   [tokenize] - command line tokenize (*default)
+   server - run tokenize server
+   lattice - lattice viewer
+   sentence - tiny sentence splitter
+   version - show version
 
-## Segmentation modes
+tokenize [-file input_file] [-dict dic_file] [-userdict user_dic_file] [-sysdict (ipa|uni)] [-simple false] [-mode (normal|search|extended)] [-split] [-json]
+  -dict string
+    	dict
+  -file string
+    	input file
+  -json
+    	outputs in JSON format
+  -mode string
+    	tokenize mode (normal|search|extended) (default "normal")
+  -simple
+    	display abbreviated dictionary contents
+  -split
+    	use tiny sentence splitter
+  -sysdict string
+    	system dict type (ipa|uni) (default "ipa")
+  -udict string
+    	user dict
+```
 
-Similar to [Kuromoji](https://www.atilika.org/), Kagome also supports _segmentation modes_ that enable various segmentations.
+```shellsession
+% # piped standard input
+% echo "すもももももももものうち" | kagome
+すもも	名詞,一般,*,*,*,*,すもも,スモモ,スモモ
+も	助詞,係助詞,*,*,*,*,も,モ,モ
+もも	名詞,一般,*,*,*,*,もも,モモ,モモ
+も	助詞,係助詞,*,*,*,*,も,モ,モ
+もも	名詞,一般,*,*,*,*,もも,モモ,モモ
+の	助詞,連体化,*,*,*,*,の,ノ,ノ
+うち	名詞,非自立,副詞可能,*,*,*,うち,ウチ,ウチ
+EOS
+```
 
-* **Normal:** Regular segmentation
-* **Search:** Use a heuristic to perform additional segmentation that is **useful for search** purposes
-* **Extended:** Similar to search mode, but also unknown words with uni-grams
+* For more details, see the [Commands section](#commands).
 
-|Untokenized|Normal|Search|Extended|
-|:-------|:---------|:---------|:---------|
-|関西国際空港|関西国際空港|関西　国際　空港|関西　国際　空港|
-|日本経済新聞|日本経済新聞|日本　経済　新聞|日本　経済　新聞|
-|シニアソフトウェアエンジニア|シニアソフトウェアエンジニア|シニア　ソフトウェア　エンジニア|シニア　ソフトウェア　エンジニア|
-|デジカメを買った|デジカメ　を　買っ　た|デジカメ　を　買っ　た|デ　ジ　カ　メ　を　買っ　た|
+### As a Go library
 
-## Programming example
+```sh
+# Install Kagome module
+go get github.com/ikawaha/kagome/v2
+```
 
 ```Go
 package main
@@ -66,12 +108,12 @@ func main() {
   if err != nil {
     panic(err)
   }
-  // wakati
+  // wakati (simple word splitting/segmentation)
   fmt.Println("---wakati---")
   seg := t.Wakati("すもももももももものうち")
   fmt.Println(seg)
 
-  // tokenize
+  // tokenize w/ morphological analysis
   fmt.Println("---tokenize---")
   tokens := t.Tokenize("すもももももももものうち")
   for _, token := range tokens {
@@ -96,17 +138,15 @@ output:
 うち	名詞,非自立,副詞可能,*,*,*,うち,ウチ,ウチ
 ```
 
-* For more examples, see the [examples directory](https://github.com/ikawaha/kagome/tree/v2/_examples).
+* For more examples, see:
+  * [examples directory](https://github.com/ikawaha/kagome/tree/v2/_examples)
+  * [GoDoc](https://pkg.go.dev/github.com/ikawaha/kagome/v2)
 
-## Reference
+## Install
 
-[![実践：形態素解析 kagome v2](https://user-images.githubusercontent.com/4232165/102152682-e281e400-3eb8-11eb-91f7-13e08a8977d9.png)](https://zenn.dev/ikawaha/books/kagome-v2-japanese-tokenizer)
+To **get the `kagome` command line tool**, choose your preferred installation method below:
 
-## Commands
-
-### Install
-
-* **Go**
+* **Go (recommended)**
 
   ```shellsession
   go install github.com/ikawaha/kagome/v2@latest
@@ -119,48 +159,20 @@ output:
   brew install ikawaha/kagome/kagome
   ```
 
-* **Docker**
-
-  * See the [Docker section](#docker) below
-
 * **Manual Install**
 
   * For manual installation, download and extract the appropriate archived file for your OS and architecture from the [releases page](https://github.com/ikawaha/kagome/releases/latest).
   * Note that the extracted binary must be placed in an accessible directory with execution permission.
 
-### Usage
+* **Docker/Docker Compose**
 
-```shellsession
-$ kagome -h
-Japanese Morphological Analyzer -- github.com/ikawaha/kagome/v2
-usage: kagome <command>
-The commands are:
-   [tokenize] - command line tokenize (*default)
-   server - run tokenize server
-   lattice - lattice viewer
-   sentence - tiny sentence splitter
-   version - show version
+  * See the [Docker section](#docker) below
 
-tokenize [-file input_file] [-dict dic_file] [-userdict user_dic_file] [-sysdict (ipa|uni)] [-simple false] [-mode (normal|search|extended)] [-split] [-json]
-  -dict string
-      dict
-  -file string
-      input file
-  -json
-      outputs in JSON format
-  -mode string
-      tokenize mode (normal|search|extended) (default "normal")
-  -simple
-      display abbreviated dictionary contents
-  -split
-      use tiny sentence splitter
-  -sysdict string
-      system dict type (ipa|uni) (default "ipa")
-  -udict string
-      user dict
-```
+## Commands
 
-#### Tokenize command
+Major sub-commands of `kagome` command line tool.
+
+### Tokenize command
 
 ```shellsession
 % # interactive/REPL mode
@@ -191,6 +203,7 @@ EOS
 
 ```shellsession
 % # JSON output
+% # (For jq command see https://jqlang.org/)
 % echo "猫" | kagome -json | jq .
 [
   {
@@ -224,7 +237,14 @@ EOS
 ```
 
 ```shellsession
-echo "私ははにわよわわわんわん" | kagome -json | jq -r '.[].pronunciation'
+% # word splitting/segmentation only (equivalent to "wakati" functionality)
+% echo "すもももももももものうち" | kagome -json | jq -r '[.[].surface] | join(" ")'
+すもも も もも も もも の うち
+```
+
+```shellsession
+% # Extract only pronunciations using jq (for Text-to-Speech purposes, etc.)
+% echo "私ははにわよわわわんわん" | kagome -json | jq -r '.[].pronunciation'
 ワタシ
 ワ
 ハニワ
@@ -235,6 +255,8 @@ echo "私ははにわよわわわんわん" | kagome -json | jq -r '.[].pronunci
 ```
 
 ### Server command
+
+For continuous usage, `kagome` provides a server mode to decouple the startup time of the tokenizer.
 
 #### RESTful API
 
@@ -253,13 +275,13 @@ Start a server and access `http://localhost:6060` in your browser.
 % kagome server &
 ```
 
-> [!IMPORTANT]
-> The demo web application uses [graphviz](https://graphviz.org/) to draw a lattice. You need graphviz to be installed on your system.
-
 ![webapp](https://raw.githubusercontent.com/wiki/ikawaha/kagome/images/demoapp.gif)
 
+> [!IMPORTANT]
+> The demo web application uses [graphviz](https://graphviz.org/) to draw a lattice. You need graphviz to be installed on your system.
+>
 > [!TIP]
-> Kagome can be compiled to WebAssembly (wasm) and run locally in a web browser. For details, see the [WebAssembly section](#webassembly).
+> Kagome can be compiled to WebAssembly (wasm) and run locally in a web browser as well. For details, see the [WebAssembly section](#webassembly).
 >
 > * Wasm Demo: [https://ikawaha.github.io/kagome/](https://ikawaha.github.io/kagome/)
 
@@ -273,40 +295,142 @@ A debug tool of tokenize process outputs a lattice in graphviz dot format.
 
 ![lattice](https://user-images.githubusercontent.com/4232165/89723585-74717000-da33-11ea-886a-baab85f7a06e.png)
 
-### Docker
+### Sentence command
+
+Split long text into sentences:
+
+```shellsession
+% echo "吾輩は猫である。名前はまだ無い。" | kagome sentence
+吾輩は猫である。
+名前はまだ無い。
+```
+
+This command is useful if a single line of data is too lengthy, and you want to avoid errors such as `bufio.Scanner: token too long`.
+
+```shellsession
+% echo "吾輩は猫である。名前はまだ無い。" | kagome -json | jq -r '[.[].surface] | join(" ")'
+吾輩 は 猫 で ある 。 名前 は まだ 無い 。
+
+% echo "吾輩は猫である。名前はまだ無い。" | kagome sentence | kagome -json | jq -r '[.[].surface] | join(" ")'
+吾輩 は 猫 で ある 。
+名前 は まだ 無い 。
+```
+
+This command is equivalent to the `-split` option of the `tokenize` command.
+
+```shellsession
+% echo "吾輩は猫である。名前はまだ無い。" | kagome -split -json | jq -r '[.[].surface] | join(" ")'
+吾輩 は 猫 で ある 。
+名前 は まだ 無い 。
+```
+
+## Dictionaries
+
+* Currently supported dictionaries by default.
+
+  |dict| source | package |
+  |:---|:---|:---|
+  |MeCab IPADIC| mecab-ipadic-2.7.0-20070801 | [github.com/ikawaha/kagome-dict/ipa](https://github.com/ikawaha/kagome-dict/tree/master/ipa)|
+  |UniDIC| unidic-mecab-2.1.2_src | [github.com/ikawaha/kagome-dict/uni](https://github.com/ikawaha/kagome-dict/tree/master/uni) |
+
+* Experimental Features
+
+  |dict|source|package|
+  |:---|:---|:---|
+  |mecab-ipadic-NEologd|mecab-ipadic-neologd| [github.com/ikawaha/kagome-ipa-neologd](https://github.com/ikawaha/kagome-dict-ipa-neologd)|
+  |Korean MeCab|mecab-ko-dic-2.1.1-20180720 | [github.com/ikawaha/kagome-dict-ko](https://github.com/ikawaha/kagome-dict-ko)|
+
+> [!NOTE]
+> For more details and differences between the dictionaries, see the [wiki](https://github.com/ikawaha/kagome/wiki/About-the-dictionary).
+
+## Segmentation modes
+
+Similar to [Kuromoji](https://www.atilika.org/), Kagome also supports various **segmentation modes** (splitting strategies) to tokenize the input text.
+
+* **Normal:** Regular segmentation
+* **Search:** Use a heuristic to perform additional segmentation that is **useful for search** purposes
+* **Extended:** Similar to search mode, but also unknown words with [uni-grams](https://en.wikipedia.org/wiki/N-gram)
+
+|Untokenized|Normal|Search|Extended|
+|:-------|:---------|:---------|:---------|
+|関西国際空港|関西国際空港|関西　国際　空港|関西　国際　空港|
+|日本経済新聞|日本経済新聞|日本　経済　新聞|日本　経済　新聞|
+|シニアソフトウェアエンジニア|シニアソフトウェアエンジニア|シニア　ソフトウェア　エンジニア|シニア　ソフトウェア　エンジニア|
+|デジカメを買った|デジカメ　を　買っ　た|デジカメ　を　買っ　た|デ　ジ　カ　メ　を　買っ　た|
+
+> [!NOTE]
+>If your purpose is for search, try changing the mode before switching to another dictionary.
+
+## Docker
 
 [![Docker](https://dockerico.blankenship.io/image/ikawaha/kagome)](https://hub.docker.com/r/ikawaha/kagome)
 
-```sh
-# Compatible architectures: AMD64, Arm64, Arm32 (Arm v5, v6 and v7)
-docker pull ikawaha/kagome:latest
+We provide `scratch`-based Docker images that simply run the `kagome` command line tool on various architectures: AMD64, Arm64, Arm32 (Arm v5, v6 and v7)
 
-# Alternatively, you can pull from GitHub Container Registry
-docker pull ghcr.io/ikawaha/kagome:latest
-```
+* Pull the image
 
-```sh
-# Interactive/REPL mode
-docker run --rm -it ikawaha/kagome:latest
+  ```sh
+  docker pull ikawaha/kagome:latest
+  ```
 
-# If pulling from GitHub Container Registry
-docker run --rm -it ghcr.io/ikawaha/kagome:latest
-```
+  ```sh
+  # Alternatively, you can pull from GitHub Container Registry
+  docker pull ghcr.io/ikawaha/kagome:latest
+  ```
 
-```sh
-# Server mode (http://localhost:6060)
-docker run --rm -p 6060:6060 ikawaha/kagome:latest server
+* Run the command via Docker
 
-# If pulling from GitHub Container Registry
-docker run --rm -p 6060:6060 ghcr.io/ikawaha/kagome:latest server
-```
+  ```sh
+  # Interactive/REPL mode
+  docker run --rm -it ikawaha/kagome:latest
+  ```
 
-### WebAssembly
+  ```sh
+  # If pulling from GitHub Container Registry
+  docker run --rm -it ghcr.io/ikawaha/kagome:latest
+  ```
 
-Kagome can be compiled to WebAssembly (wasm) and run in a web browser.
+* Run the server via Docker
 
-You can see how kagome wasm works in the [demo site](http://ikawaha.github.io/kagome/). The source code can be found in `./_examples/wasm`.
+  ```sh
+  # Server mode (http://localhost:6060)
+  docker run --rm -p 6060:6060 ikawaha/kagome:latest server
+  ```
 
-## Licence
+  ```sh
+  # If pulling from GitHub Container Registry
+  docker run --rm -p 6060:6060 ghcr.io/ikawaha/kagome:latest server
+  ```
+
+* `docker-compose.yml` example
+
+  ```yaml
+  services:
+    kagome:
+      image: ikawaha/kagome:latest
+      ports: ["6060:6060"]
+      command: server
+      restart: unless-stopped
+  ```
+
+> **Note:** Base image doesn't include Graphviz. For lattice visualization, see [examples](./_examples/server_docker_graphviz/).
+
+## WebAssembly
+
+Kagome compiles to WebAssembly for browser use.
+
+* **Live demo:** [https://ikawaha.github.io/kagome/](https://ikawaha.github.io/kagome/)
+* **Source code:** [./_examples/wasm](./_examples/wasm)
+
+## Reference
+
+* Detailed Reference Manual in Japanese:
+
+  [![実践：形態素解析 kagome v2](https://user-images.githubusercontent.com/4232165/102152682-e281e400-3eb8-11eb-91f7-13e08a8977d9.png)](https://zenn.dev/ikawaha/books/kagome-v2-japanese-tokenizer)
+
+* Community Wiki in English:
+  * [https://github.com/ikawaha/kagome/wiki](https://github.com/ikawaha/kagome/wiki)
+
+## License
 
 * MIT

--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ A debug tool of tokenize process outputs a lattice in graphviz dot format.
 
 ### Docker
 
-[![Docker](https://dockeri.co/image/ikawaha/kagome)](https://hub.docker.com/r/ikawaha/kagome)
+[![Docker](https://dockerico.blankenship.io/image/ikawaha/kagome)](https://hub.docker.com/r/ikawaha/kagome)
 
 ```sh
 # Compatible architectures: AMD64, Arm64, Arm32 (Arm v5, v6 and v7)

--- a/_examples/server_docker_graphviz/Dockerfile
+++ b/_examples/server_docker_graphviz/Dockerfile
@@ -1,0 +1,12 @@
+FROM ikawaha/kagome:latest AS base
+
+FROM alpine:latest
+
+COPY --from=base --chown=user:group /kagome /usr/local/bin/kagome
+
+RUN apk add --no-cache graphviz
+
+EXPOSE 6060
+
+ENTRYPOINT ["/usr/local/bin/kagome"]
+CMD ["server"]

--- a/_examples/server_docker_graphviz/README.md
+++ b/_examples/server_docker_graphviz/README.md
@@ -1,0 +1,24 @@
+# Example of using Kagome's Docker Image with Graphviz support
+
+If you are familiar with `docker` and `docker compose`, you can easily set up a Kagome server with [Graphviz](https://graphviz.org/) support for visualizing lattice structures.
+
+> [!NOTE]
+> The [docker image we provide](https://hub.docker.com/r/ikawaha/kagome) does not include Graphviz due to size constraints. This example shows how to build a custom docker image that includes Graphviz.
+
+* [Dockerfile](./Dockerfile)
+* [docker-compose.yml](./docker-compose.yml)
+* [userdict.txt](./userdict.txt)
+
+## Bootstrapping the Environment
+
+```shell
+docker compose up -d
+```
+
+After running the above command, you can access the Kagome server at `http://localhost:6060/`.
+
+## Shutting Down the Environment
+
+```shell
+docker compose down
+```

--- a/_examples/server_docker_graphviz/docker-compose.yml
+++ b/_examples/server_docker_graphviz/docker-compose.yml
@@ -1,0 +1,13 @@
+services:
+  kagome:
+    image: kagome:local
+    init: true
+    build:
+      context: .
+      dockerfile: Dockerfile
+    command: server -userdict="/data/userdict.txt"
+    ports:
+      - "6060:6060"
+    volumes:
+      - ./userdict.txt:/data/userdict.txt
+    restart: unless-stopped

--- a/_examples/server_docker_graphviz/userdict.txt
+++ b/_examples/server_docker_graphviz/userdict.txt
@@ -1,0 +1,15 @@
+##
+## This file should use UTF-8 encoding
+##
+## User dictionary format:
+## <text>,<text>,<reading>,<part-of-speech>
+## or
+## <text>,<token1> <token2> ... <tokenn>,<reading1> <reading2> ... <readingn>,<part-of-speech>
+##
+
+# Custom reading for former sumo wrestler Asashoryu
+朝青龍,朝青龍,アサショウリュウ,カスタム人名
+
+# Custom segmentation for long entries
+日本経済新聞,日本 経済 新聞,ニホン ケイザイ シンブン,カスタム名詞
+関西国際空港,関西 国際 空港,カンサイ コクサイ クウコウ,テスト名詞


### PR DESCRIPTION
* Fixes #367
  
  * Replaces Docker badge image URL to the new one
  * Add `Sentence` command description
  * Add Index to the top
  * Swap sections for readability
  * Fix some typos
  * Add Dockerfile example under ./_examples for Kagome server w/ Graphviz support

Please check if the changes matches with your will.