### PR TITLE
feat(server): redesign demo UI with real-time lattice and zoom

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ Start a server and access `http://localhost:6060` in your browser.
 % kagome server &
 ```
 
-![webapp](https://raw.githubusercontent.com/wiki/ikawaha/kagome/images/demoapp.gif)
+<video src="https://github.com/user-attachments/assets/172d8b0c-be9a-4ee5-bdff-315a0eeee85b" controls width="100%"></video>
 
 > [!IMPORTANT]
 > The demo web application uses [graphviz](https://graphviz.org/) to draw a lattice. You need graphviz to be installed on your system.

--- a/cmd/server/asset/demo.css
+++ b/cmd/server/asset/demo.css
@@ -152,3 +152,31 @@ div#center {
     stroke: #e67e00 !important;
     stroke-width: 2px !important;
 }
+.download-wrap {
+    position: relative;
+    display: inline-block;
+}
+.download-menu {
+    display: none;
+    position: absolute;
+    right: 0;
+    top: 100%;
+    margin-top: 2px;
+    background: #fff;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    box-shadow: 0 2px 6px rgba(0,0,0,0.15);
+    z-index: 100;
+    min-width: 80px;
+}
+.download-menu.open {
+    display: block;
+}
+.download-item {
+    padding: 6px 14px;
+    cursor: pointer;
+    font-size: 0.9em;
+}
+.download-item:hover {
+    background: #e0e0e0;
+}

--- a/cmd/server/asset/demo.css
+++ b/cmd/server/asset/demo.css
@@ -1,0 +1,154 @@
+body {
+    text-align: center;
+}
+div#center {
+    width: 90%;
+    max-width: 1400px;
+    margin: 0 auto;
+    text-align: left;
+}
+.tbl {
+    width: 100%;
+    border-collapse: separate;
+}
+.tbl th {
+    width: 20%;
+    padding: 6px;
+    text-align: left;
+    vertical-align: top;
+    color: #333;
+    background-color: #eee;
+    border: 1px solid #b9b9b9;
+}
+.tbl td {
+    padding: 6px;
+    background-color: #fff;
+    border: 1px solid #b9b9b9;
+}
+.frm {
+    min-height: 10px;
+    padding: 0 10px 0;
+    margin-bottom: 20px;
+    background-color: #f5f5f5;
+    border: 1px solid #e3e3e3;
+    -webkit-border-radius: 4px;
+    -moz-border-radius: 4px;
+    border-radius: 4px;
+    -webkit-box-shadow: inset 0 1px 1px rgba(0,0,0,0.05);
+    -moz-box-shadow: inset 0 1px 1px rgba(0,0,0,0.05);
+    box-shadow: inset 0 1px 1px rgba(0,0,0,0.05);
+}
+.txar {
+    border: 10px;
+    padding: 10px;
+    font-size: 1.1em;
+    font-family: Arial, sans-serif;
+    border: solid 1px #ccc;
+    margin: 0;
+    width: 80%;
+    -webkit-border-radius: 3px;
+    -moz-border-radius: 3px;
+    border-radius: 3px;
+    -moz-box-shadow: inset 0 0 4px rgba(0,0,0,0.2);
+    -webkit-box-shadow: inset 0 0 4px rgba(0, 0, 0, 0.2);
+    box-shadow: inset 0 0 4px rgba(0, 0, 0, 0.2);
+}
+#box {
+    width: 100%;
+    margin: 10px;
+    height: auto;
+}
+#rbox {
+    width: 15%;
+    float: right;
+}
+#results-row {
+    display: flex;
+    flex-direction: row;
+    gap: 16px;
+    align-items: flex-start;
+}
+#morphs-panel {
+    flex: 0 0 auto;
+    align-self: flex-start;
+    min-width: 360px;
+}
+#lattice-area {
+    flex: 1 1 auto;
+    align-self: flex-start;
+    min-width: 0;
+}
+#lattice-output {
+    overflow: auto;
+    max-height: 500px;
+}
+#lattice-output svg {
+    display: block;
+}
+#lattice-error {
+    color: #c00;
+    font-weight: bold;
+}
+#lattice-controls {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin-bottom: 6px;
+}
+/* ズームステッパー: ［－］100%［＋］を一体化 */
+.zoom-stepper {
+    display: inline-flex;
+    align-items: center;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    overflow: hidden;
+}
+.zoom-stepper button {
+    border: none;
+    padding: 2px 10px;
+    background: #f5f5f5;
+    cursor: pointer;
+    font-size: 1em;
+    line-height: 1.6;
+}
+.zoom-stepper button:hover {
+    background: #e0e0e0;
+}
+#zoom-label {
+    display: inline-block;
+    min-width: 3.5em;
+    text-align: center;
+    padding: 2px 6px;
+    background: #fff;
+    border-left: 1px solid #ccc;
+    border-right: 1px solid #ccc;
+    font-size: 0.9em;
+    font-variant-numeric: tabular-nums;
+}
+/* Fit / Reset: 個別のアクションボタン */
+.zoom-action {
+    padding: 2px 10px;
+    cursor: pointer;
+    font-size: 0.9em;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    background: #f5f5f5;
+    line-height: 1.6;
+}
+.zoom-action:hover {
+    background: #e0e0e0;
+}
+#morphs tr {
+    cursor: pointer;
+}
+#morphs tr:hover td {
+    background-color: #fffbe6;
+}
+#morphs tr.morph-selected td {
+    background-color: #fff3cd;
+}
+#lattice-output svg g.node.morph-highlight ellipse {
+    fill: #ffe066 !important;
+    stroke: #e67e00 !important;
+    stroke-width: 2px !important;
+}

--- a/cmd/server/asset/demo.html
+++ b/cmd/server/asset/demo.html
@@ -49,6 +49,13 @@
         </span>
         <button class="zoom-action" onclick="fitZoom()" title="全体を表示">Fit</button>
         <button class="zoom-action" onclick="resetZoom()" title="等倍に戻す">Reset</button>
+        <div class="download-wrap">
+          <button class="zoom-action" onclick="toggleDownloadMenu(event)" title="ダウンロード形式を選択">Download ▾</button>
+          <div id="download-menu" class="download-menu">
+            <div class="download-item" onclick="downloadAs('svg')">SVG</div>
+            <div class="download-item" onclick="downloadAs('png')">PNG</div>
+          </div>
+        </div>
       </div>
       <div id="lattice-output"></div>
     </div>

--- a/cmd/server/asset/demo.html
+++ b/cmd/server/asset/demo.html
@@ -13,14 +13,14 @@
 <body>
 <div id="center">
   <h1>Kagome demo</h1>
-  <form class="frm" action="/_demo" method="POST" oninput="tokenize(); scheduleLattice();">
+  <form class="frm" action="/_demo" method="POST" oninput="tokenize(); scheduleLattice();" onsubmit="return false;">
     <div id="box">
     <textarea id="inp" class="txar" rows="3" name="s"
               placeholder="Enter Japanese text below.">{{.Sentence}}</textarea>
       <div id="rbox">
         <div><label><input type="radio" name="r" value="Normal" checked>Normal</label></div>
-        <div><label><input type="radio" name="r" value="Search" {{if eq .RadioOpt "search"}}checked{{end}}>Search</label></div>
-        <div><label><input type="radio" name="r" value="Extended" {{if eq .RadioOpt "extended"}}checked{{end}}>Extended</label></div>
+        <div><label><input type="radio" name="r" value="Search" {{if eq .RadioOpt "Search"}}checked{{end}}>Search</label></div>
+        <div><label><input type="radio" name="r" value="Extended" {{if eq .RadioOpt "Extended"}}checked{{end}}>Extended</label></div>
       </div>
     </div>
   </form>
@@ -28,13 +28,13 @@
   <div id="results-row">
     <div id="morphs-panel">
       <table class="tbl">
-        <thread><tr>
+        <thead><tr>
           <th>Surface</th>
           <th>Part-of-Speech</th>
           <th>Base Form</th>
           <th>Reading</th>
           <th>Pronunciation</th>
-        </tr></thread>
+        </tr></thead>
         <tbody id="morphs">
         </tbody>
       </table>

--- a/cmd/server/asset/demo.html
+++ b/cmd/server/asset/demo.html
@@ -1,83 +1,9 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
-  <style type="text/css">
-      body {
-          text-align: center;
-      }
-      div#center{
-          width: 800px;
-          margin: 0 auto;
-          text-align: left;
-      }
-      .tbl{
-          width: 100%;
-          border-collapse: separate;
-      }
-      .tbl th{
-          width: 20%;
-          padding: 6px;
-          text-align: left;
-          vertical-align: top;
-          color: #333;
-          background-color: #eee;
-          border: 1px solid #b9b9b9;
-      }
-      .tbl td{
-          padding: 6px;
-          background-color: #fff;
-          border: 1px solid #b9b9b9;
-      }
-      .frm {
-          min-height: 10px;
-          padding: 0 10px 0;
-          margin-bottom: 20px;
-          background-color: #f5f5f5;
-          border: 1px solid #e3e3e3;
-          -webkit-border-radius: 4px;
-          -moz-border-radius: 4px;
-          border-radius: 4px;
-          -webkit-box-shadow: inset 0 1px 1px rgba(0,0,0,0.05);
-          -moz-box-shadow: inset 0 1px 1px rgba(0,0,0,0.05);
-          box-shadow: inset 0 1px 1px rgba(0,0,0,0.05);
-      }
-      .txar {
-          border:10px;
-          padding:10px;
-          font-size:1.1em;
-          font-family:Arial, sans-serif;
-          border:solid 1px #ccc;
-          margin:0;
-          width:80%;
-          -webkit-border-radius: 3px;
-          -moz-border-radius: 3px;
-          border-radius: 3px;
-          -moz-box-shadow: inset 0 0 4px rgba(0,0,0,0.2);
-          -webkit-box-shadow: inset 0 0 4px rgba(0, 0, 0, 0.2);
-          box-shadow: inset 0 0 4px rgba(0, 0, 0, 0.2);
-      }
-      .btn {
-          background: -moz-linear-gradient(top,#FFF 0%,#EEE);
-          background: -webkit-gradient(linear, left top, left bottom, from(#FFF), to(#EEE));
-          border: 1px solid #DDD;
-          border-radius: 3px;
-          color:#111;
-          width: 100px;
-          padding: 5px 0;
-          margin: 0;
-      }
-      #box {
-          width:100%;
-          margin:10px;
-          height:auto;
-      }
-      #rbox {
-          width:15%;
-          float:right;
-      }
-  </style>
   <meta charset="UTF-8">
   <title>Kagome demo - Japanese morphological analyzer</title>
+  <link rel="stylesheet" href="/asset/demo.css">
   <!-- for IE6-8 support of HTML elements -->
   <!--[if lt IE 9]>
   <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
@@ -87,7 +13,7 @@
 <body>
 <div id="center">
   <h1>Kagome demo</h1>
-  <form class="frm" action="/_demo" method="POST" oninput="tokenize()" target="_blank">
+  <form class="frm" action="/_demo" method="POST" oninput="tokenize(); scheduleLattice();">
     <div id="box">
     <textarea id="inp" class="txar" rows="3" name="s"
               placeholder="Enter Japanese text below.">{{.Sentence}}</textarea>
@@ -96,60 +22,39 @@
         <div><label><input type="radio" name="r" value="Search" {{if eq .RadioOpt "search"}}checked{{end}}>Search</label></div>
         <div><label><input type="radio" name="r" value="Extended" {{if eq .RadioOpt "extended"}}checked{{end}}>Extended</label></div>
       </div>
-      <p><input class="btn" type="submit" name="lattice" value="Lattice"/></p>
     </div>
   </form>
 
-  <table class="tbl">
-    <thread><tr>
-      <th>Surface</th>
-      <th>Part-of-Speech</th>
-      <th>Base Form</th>
-      <th>Reading</th>
-      <th>Pronunciation</th>
-    </tr></thread>
-    <tbody id="morphs">
-    </tbody>
-  </table>
+  <div id="results-row">
+    <div id="morphs-panel">
+      <table class="tbl">
+        <thread><tr>
+          <th>Surface</th>
+          <th>Part-of-Speech</th>
+          <th>Base Form</th>
+          <th>Reading</th>
+          <th>Pronunciation</th>
+        </tr></thread>
+        <tbody id="morphs">
+        </tbody>
+      </table>
+    </div>
+    <div id="lattice-area">
+      <div id="lattice-error"></div>
+      <div id="lattice-controls" style="display:none;">
+        <span class="zoom-stepper">
+          <button onclick="zoomOut()" title="縮小">－</button>
+          <span id="zoom-label">100%</span>
+          <button onclick="zoomIn()" title="拡大">＋</button>
+        </span>
+        <button class="zoom-action" onclick="fitZoom()" title="全体を表示">Fit</button>
+        <button class="zoom-action" onclick="resetZoom()" title="等倍に戻す">Reset</button>
+      </div>
+      <div id="lattice-output"></div>
+    </div>
+  </div>
 </div>
 
-<script>
-    function cb(data, status) {
-        //console.log(data);
-        //console.log(status);
-        if(status == "success" && Array.isArray(data.tokens)){
-            $("#morphs").empty();
-            $.each(data.tokens, function(i, val) {
-                pos = (val.pos == null) ? "*" : val.pos;
-                base = val.base_form != "" ? val.base_form : "*";
-                reading = val.reading != "" ? val.reading : "*";
-                pronoun = val.pronunciation!= "" ? val.pronunciation : "*";
-                $("#morphs").append(
-                    "<tr>"+"<td>" + val.surface + "</td>" +
-                    "<td>" + pos + "</td>"+
-                    "<td>" + base + "</td>"+
-                    "<td>" + reading + "</td>"+
-                    "<td>" + pronoun + "</td>"+
-                    "</tr>"
-                );
-            });
-        }
-    }
-
-    function tokenize() {
-        var s = document.getElementById("inp").value;
-        var m = $('input[name="r"]').filter(':checked').val();
-        var o = {"sentence" : s, "mode" : m};
-        $.post('./tokenize', JSON.stringify(o), cb, 'json');
-    }
-
-    $('input[name="r"]:radio').change( function() {
-        var s = document.getElementById("inp").value;
-        var m = $('input[name="r"]').filter(':checked').val();
-        var o = {"sentence" : s, "mode" : m};
-        $.post('./a', JSON.stringify(o), cb, 'json');
-    })
-</script>
-
+<script src="/asset/demo.js"></script>
 </body>
 </html>

--- a/cmd/server/asset/demo.html
+++ b/cmd/server/asset/demo.html
@@ -48,7 +48,7 @@
           <button onclick="zoomIn()" title="拡大">＋</button>
         </span>
         <button class="zoom-action" onclick="fitZoom()" title="全体を表示">Fit</button>
-        <button class="zoom-action" onclick="resetZoom()" title="等倍に戻す">Reset</button>
+
         <div class="download-wrap">
           <button class="zoom-action" onclick="toggleDownloadMenu(event)" title="ダウンロード形式を選択">Download ▾</button>
           <div id="download-menu" class="download-menu">

--- a/cmd/server/asset/demo.js
+++ b/cmd/server/asset/demo.js
@@ -1,0 +1,218 @@
+function cb(data, status) {
+    if (status === "success" && Array.isArray(data.tokens)) {
+        $("#morphs").empty();
+        $.each(data.tokens, function(i, val) {
+            var pos     = (val.pos == null || val.pos.length === 0) ? "*" : val.pos.join(",");
+            var base    = val.base_form     != "" ? val.base_form     : "*";
+            var reading = val.reading       != "" ? val.reading       : "*";
+            var pronoun = val.pronunciation != "" ? val.pronunciation : "*";
+            var row = $("<tr>").attr("data-morph-idx", i);
+            row.append($("<td>").text(val.surface));
+            row.append($("<td>").text(pos));
+            row.append($("<td>").text(base));
+            row.append($("<td>").text(reading));
+            row.append($("<td>").text(pronoun));
+            row.click(function() {
+                focusLatticeNode(parseInt($(this).attr("data-morph-idx"), 10));
+            });
+            $("#morphs").append(row);
+        });
+    }
+}
+
+function focusLatticeNode(idx) {
+    var svgEl = document.querySelector('#lattice-output svg');
+
+    // clear table row highlight
+    document.querySelectorAll('#morphs tr.morph-selected').forEach(function(tr) {
+        tr.classList.remove('morph-selected');
+    });
+    var rows = document.querySelectorAll('#morphs tr');
+    if (idx >= 0 && idx < rows.length) {
+        rows[idx].classList.add('morph-selected');
+    }
+
+    if (!svgEl || !cachedBestNodes) return;
+
+    // clear previous SVG highlight
+    svgEl.querySelectorAll('g.node.morph-highlight').forEach(function(g) {
+        g.classList.remove('morph-highlight');
+    });
+
+    if (idx < 0 || idx >= cachedBestNodes.length) return;
+
+    var targetNode = cachedBestNodes[idx].el;
+    targetNode.classList.add('morph-highlight');
+
+    // scroll the node into view within #lattice-output (horizontal and vertical)
+    var ellipse = targetNode.querySelector('ellipse');
+    if (ellipse) {
+        var outEl = document.getElementById('lattice-output');
+        var elRect = ellipse.getBoundingClientRect();
+        var outRect = outEl.getBoundingClientRect();
+        if (elRect.left < outRect.left || elRect.right > outRect.right) {
+            outEl.scrollLeft += elRect.left - outRect.left - (outRect.width - elRect.width) / 2;
+        }
+        if (elRect.top < outRect.top || elRect.bottom > outRect.bottom) {
+            outEl.scrollTop += elRect.top - outRect.top - (outRect.height - elRect.height) / 2;
+        }
+    }
+}
+
+function tokenize() {
+    var s = document.getElementById("inp").value;
+    var m = $('input[name="r"]').filter(':checked').val();
+    var o = {"sentence": s, "mode": m};
+    $.post('./tokenize', JSON.stringify(o), cb, 'json');
+}
+
+// ズーム管理
+var currentZoom = 1.0;
+var svgOrigDims = null;
+var svgOrigPx   = null; // SVG のピクセル換算サイズ（Fit 計算用）
+var cachedBestNodes = null; // SVG ロード後にキャッシュするベストパスノード
+var zoomStep = 0.25;
+var minZoom = 0.25;
+var maxZoom = 4.0;
+
+// SVG 属性値（pt 単位など）をピクセルに換算する（1pt = 96/72px）
+function toPx(value, unit) {
+    return unit === 'pt' ? value * 96 / 72 : value;
+}
+
+// graphviz SVG は y-up 座標系のため上部に空白が生じる。
+// background polygon の上端までスクロールしてスキップする。
+function scrollToSVGContent() {
+    var outEl = document.getElementById('lattice-output');
+    var svgEl = outEl && outEl.querySelector('svg');
+    if (!svgEl) return;
+    var polygon = svgEl.querySelector('polygon');
+    if (polygon) {
+        var emptyTop = polygon.getBoundingClientRect().top - svgEl.getBoundingClientRect().top;
+        if (emptyTop > 0) {
+            outEl.scrollTop = emptyTop;
+        }
+    }
+}
+
+function applyZoom() {
+    var svgEl = document.querySelector('#lattice-output svg');
+    if (!svgEl || !svgOrigDims) return;
+    svgEl.setAttribute('width',  (svgOrigDims.width  * currentZoom) + svgOrigDims.wUnit);
+    svgEl.setAttribute('height', (svgOrigDims.height * currentZoom) + svgOrigDims.hUnit);
+    document.getElementById('zoom-label').textContent = Math.round(currentZoom * 100) + '%';
+    scrollToSVGContent();
+}
+
+function zoomIn() {
+    currentZoom = Math.min(maxZoom, parseFloat((currentZoom + zoomStep).toFixed(2)));
+    applyZoom();
+}
+
+function zoomOut() {
+    currentZoom = Math.max(minZoom, parseFloat((currentZoom - zoomStep).toFixed(2)));
+    applyZoom();
+}
+
+function resetZoom() {
+    currentZoom = 1.0;
+    applyZoom();
+}
+
+function fitZoom() {
+    if (!svgOrigPx) return;
+    var outEl = document.getElementById('lattice-output');
+    var containerW = outEl.clientWidth;
+    // CSS の max-height (500px) をコンテナの高さとして使う
+    var containerH = parseInt(window.getComputedStyle(outEl).maxHeight) || outEl.clientHeight;
+    var zoom = Math.min(containerW / svgOrigPx.width, containerH / svgOrigPx.height);
+    currentZoom = parseFloat(Math.max(minZoom, Math.min(maxZoom, zoom)).toFixed(2));
+    applyZoom();
+}
+
+// Ctrl+ホイールでズーム
+document.getElementById('lattice-output').addEventListener('wheel', function(e) {
+    if (e.ctrlKey || e.metaKey) {
+        e.preventDefault();
+        if (e.deltaY < 0) { zoomIn(); } else { zoomOut(); }
+    }
+}, { passive: false });
+
+function updateLattice() {
+    var s = document.getElementById("inp").value;
+    var m = $('input[name="r"]').filter(':checked').val();
+    $.post('./lattice', {s: s, r: m}, function(data) {
+        var errEl = document.getElementById('lattice-error');
+        var outEl = document.getElementById('lattice-output');
+        var ctrlEl = document.getElementById('lattice-controls');
+        if (data.error) {
+            errEl.textContent = 'Error: ' + data.error;
+            outEl.innerHTML = '';
+            ctrlEl.style.display = 'none';
+            svgOrigDims = null;
+            svgOrigPx   = null;
+            cachedBestNodes = null;
+        } else {
+            errEl.textContent = '';
+            if (typeof outEl.setHTML === 'function') {
+                outEl.setHTML(data.svg || '');
+            } else {
+                outEl.innerHTML = data.svg || '';
+            }
+            var svgEl = outEl.querySelector('svg');
+            if (svgEl) {
+                // オリジナルのサイズを保存してズームをリセット
+                var wAttr = svgEl.getAttribute('width')  || '';
+                var hAttr = svgEl.getAttribute('height') || '';
+                var wM = wAttr.match(/^([0-9.]+)([a-z]*)$/i);
+                var hM = hAttr.match(/^([0-9.]+)([a-z]*)$/i);
+                svgOrigDims = {
+                    width:  wM ? parseFloat(wM[1]) : 100,
+                    height: hM ? parseFloat(hM[1]) : 100,
+                    wUnit:  wM ? wM[2] : '',
+                    hUnit:  hM ? hM[2] : '',
+                };
+                // pt → px 換算して Fit 計算用に保存
+                svgOrigPx = {
+                    width:  toPx(svgOrigDims.width,  svgOrigDims.wUnit),
+                    height: toPx(svgOrigDims.height, svgOrigDims.hUnit),
+                };
+                // best-path nodes have peripheries=2 in DOT → two <ellipse> in SVG
+                // BOS/EOS are also in the optimal path and get peripheries=2, so exclude them by label
+                cachedBestNodes = [];
+                svgEl.querySelectorAll('g.node').forEach(function(g) {
+                    var ellipses = g.querySelectorAll('ellipse');
+                    if (ellipses.length >= 2) {
+                        var firstText = g.querySelector('text');
+                        var label = firstText ? firstText.textContent.trim() : '';
+                        if (label === 'BOS' || label === 'EOS') return;
+                        cachedBestNodes.push({ el: g, cx: parseFloat(ellipses[0].getAttribute('cx') || '0') });
+                    }
+                });
+                // rankdir=LR なので cx 昇順 = 形態素の出現順
+                cachedBestNodes.sort(function(a, b) { return a.cx - b.cx; });
+                ctrlEl.style.display = '';
+                fitZoom(); // 全体が収まる倍率で表示
+            }
+        }
+    }, 'json');
+}
+
+var latticeTimer = null;
+function scheduleLattice() {
+    if (latticeTimer !== null) {
+        clearTimeout(latticeTimer);
+    }
+    latticeTimer = setTimeout(function() {
+        latticeTimer = null;
+        updateLattice();
+    }, 500);
+}
+
+$('input[name="r"]:radio').change(function() {
+    var s = document.getElementById("inp").value;
+    var m = $('input[name="r"]').filter(':checked').val();
+    var o = {"sentence": s, "mode": m};
+    $.post('./tokenize', JSON.stringify(o), cb, 'json');
+    updateLattice();
+});

--- a/cmd/server/asset/demo.js
+++ b/cmd/server/asset/demo.js
@@ -66,22 +66,19 @@ function tokenize() {
     $.post('./tokenize', JSON.stringify(o), cb, 'json');
 }
 
-// ズーム管理
+// zoom
 var currentZoom = 1.0;
 var svgOrigDims = null;
-var svgOrigPx   = null; // SVG のピクセル換算サイズ（Fit 計算用）
-var cachedBestNodes = null; // SVG ロード後にキャッシュするベストパスノード
+var svgOrigPx   = null;
+var cachedBestNodes = null;
 var zoomStep = 0.25;
 var minZoom = 0.25;
 var maxZoom = 4.0;
 
-// SVG 属性値（pt 単位など）をピクセルに換算する（1pt = 96/72px）
 function toPx(value, unit) {
     return unit === 'pt' ? value * 96 / 72 : value;
 }
 
-// graphviz SVG は y-up 座標系のため上部に空白が生じる。
-// background polygon の上端までスクロールしてスキップする。
 function scrollToSVGContent() {
     var outEl = document.getElementById('lattice-output');
     var svgEl = outEl && outEl.querySelector('svg');
@@ -123,14 +120,12 @@ function fitZoom() {
     if (!svgOrigPx) return;
     var outEl = document.getElementById('lattice-output');
     var containerW = outEl.clientWidth;
-    // CSS の max-height (500px) をコンテナの高さとして使う
     var containerH = parseInt(window.getComputedStyle(outEl).maxHeight) || outEl.clientHeight;
     var zoom = Math.min(containerW / svgOrigPx.width, containerH / svgOrigPx.height);
     currentZoom = parseFloat(Math.max(minZoom, Math.min(maxZoom, zoom)).toFixed(2));
     applyZoom();
 }
 
-// Ctrl+ホイールでズーム
 document.getElementById('lattice-output').addEventListener('wheel', function(e) {
     if (e.ctrlKey || e.metaKey) {
         e.preventDefault();
@@ -161,7 +156,6 @@ function updateLattice() {
             }
             var svgEl = outEl.querySelector('svg');
             if (svgEl) {
-                // オリジナルのサイズを保存してズームをリセット
                 var wAttr = svgEl.getAttribute('width')  || '';
                 var hAttr = svgEl.getAttribute('height') || '';
                 var wM = wAttr.match(/^([0-9.]+)([a-z]*)$/i);
@@ -172,7 +166,6 @@ function updateLattice() {
                     wUnit:  wM ? wM[2] : '',
                     hUnit:  hM ? hM[2] : '',
                 };
-                // pt → px 換算して Fit 計算用に保存
                 svgOrigPx = {
                     width:  toPx(svgOrigDims.width,  svgOrigDims.wUnit),
                     height: toPx(svgOrigDims.height, svgOrigDims.hUnit),
@@ -189,10 +182,9 @@ function updateLattice() {
                         cachedBestNodes.push({ el: g, cx: parseFloat(ellipses[0].getAttribute('cx') || '0') });
                     }
                 });
-                // rankdir=LR なので cx 昇順 = 形態素の出現順
                 cachedBestNodes.sort(function(a, b) { return a.cx - b.cx; });
                 ctrlEl.style.display = '';
-                fitZoom(); // 全体が収まる倍率で表示
+                fitZoom();
             }
         }
     }, 'json');

--- a/cmd/server/asset/demo.js
+++ b/cmd/server/asset/demo.js
@@ -13,7 +13,8 @@ function cb(data, status) {
             row.append($("<td>").text(reading));
             row.append($("<td>").text(pronoun));
             row.click(function() {
-                focusLatticeNode(parseInt($(this).attr("data-morph-idx"), 10));
+                var idx = parseInt($(this).attr("data-morph-idx"), 10);
+                focusLatticeNode($(this).hasClass('morph-selected') ? -1 : idx);
             });
             $("#morphs").append(row);
         });
@@ -93,29 +94,67 @@ function scrollToSVGContent() {
     }
 }
 
-function applyZoom() {
+function getZoomAnchor(outEl, svgEl) {
+    if (!svgOrigPx) return null;
+    var curW = svgOrigPx.width  * currentZoom;
+    var curH = svgOrigPx.height * currentZoom;
+    // 選択中の形態素ノードがあれば、その中心を基準にする
+    // getBoundingClientRect() を使うことで graphviz の内部座標系に依存せず正確な位置を取得する
+    var highlight = svgEl && svgEl.querySelector('g.node.morph-highlight ellipse');
+    if (highlight) {
+        var elRect  = highlight.getBoundingClientRect();
+        var outRect = outEl.getBoundingClientRect();
+        var elCenterX = (elRect.left + elRect.right)  / 2 - outRect.left + outEl.scrollLeft;
+        var elCenterY = (elRect.top  + elRect.bottom) / 2 - outRect.top  + outEl.scrollTop;
+        return {
+            fracX: elCenterX / curW,
+            fracY: elCenterY / curH,
+            viewportOffsetX: outEl.clientWidth  / 2,
+            viewportOffsetY: outEl.clientHeight / 2,
+        };
+    }
+    // なければ表示領域の中心を基準にする
+    return {
+        fracX: (outEl.scrollLeft + outEl.clientWidth  / 2) / curW,
+        fracY: (outEl.scrollTop  + outEl.clientHeight / 2) / curH,
+        viewportOffsetX: outEl.clientWidth  / 2,
+        viewportOffsetY: outEl.clientHeight / 2,
+    };
+}
+
+function applyZoom(anchor) {
     var svgEl = document.querySelector('#lattice-output svg');
+    var outEl = document.getElementById('lattice-output');
     if (!svgEl || !svgOrigDims) return;
     svgEl.setAttribute('width',  (svgOrigDims.width  * currentZoom) + svgOrigDims.wUnit);
     svgEl.setAttribute('height', (svgOrigDims.height * currentZoom) + svgOrigDims.hUnit);
     document.getElementById('zoom-label').textContent = Math.round(currentZoom * 100) + '%';
-    scrollToSVGContent();
+    if (anchor && svgOrigPx) {
+        var newW = svgOrigPx.width  * currentZoom;
+        var newH = svgOrigPx.height * currentZoom;
+        outEl.scrollLeft = Math.max(0, newW * anchor.fracX - anchor.viewportOffsetX);
+        outEl.scrollTop  = Math.max(0, newH * anchor.fracY - anchor.viewportOffsetY);
+    } else {
+        scrollToSVGContent();
+    }
 }
 
 function zoomIn() {
+    var outEl = document.getElementById('lattice-output');
+    var svgEl = outEl && outEl.querySelector('svg');
+    var anchor = getZoomAnchor(outEl, svgEl);
     currentZoom = Math.min(maxZoom, parseFloat((currentZoom + zoomStep).toFixed(2)));
-    applyZoom();
+    applyZoom(anchor);
 }
 
 function zoomOut() {
+    var outEl = document.getElementById('lattice-output');
+    var svgEl = outEl && outEl.querySelector('svg');
+    var anchor = getZoomAnchor(outEl, svgEl);
     currentZoom = Math.max(minZoom, parseFloat((currentZoom - zoomStep).toFixed(2)));
-    applyZoom();
+    applyZoom(anchor);
 }
 
-function resetZoom() {
-    currentZoom = 1.0;
-    applyZoom();
-}
 
 function fitZoom() {
     if (!svgOrigPx) return;
@@ -160,11 +199,7 @@ function updateLattice() {
             cachedBestNodes = null;
         } else {
             errEl.textContent = '';
-            if (typeof outEl.setHTML === 'function') {
-                outEl.setHTML(data.svg || '');
-            } else {
-                outEl.innerHTML = data.svg || '';
-            }
+            outEl.innerHTML = data.svg || '';
             cachedSVGString = data.svg || null;
             var svgEl = outEl.querySelector('svg');
             if (svgEl) {
@@ -189,7 +224,8 @@ function updateLattice() {
                     var ellipses = g.querySelectorAll('ellipse');
                     if (ellipses.length >= 2) {
                         var firstText = g.querySelector('text');
-                        var label = firstText ? firstText.textContent.trim() : '';
+                        if (!firstText) return;
+                        var label = firstText.textContent.trim();
                         if (label === 'BOS' || label === 'EOS') return;
                         cachedBestNodes.push({ el: g, cx: parseFloat(ellipses[0].getAttribute('cx') || '0') });
                     }

--- a/cmd/server/asset/demo.js
+++ b/cmd/server/asset/demo.js
@@ -71,6 +71,7 @@ var currentZoom = 1.0;
 var svgOrigDims = null;
 var svgOrigPx   = null;
 var cachedBestNodes = null;
+var cachedSVGString = null;
 var zoomStep = 0.25;
 var minZoom = 0.25;
 var maxZoom = 4.0;
@@ -142,6 +143,7 @@ function updateLattice() {
         svgOrigDims = null;
         svgOrigPx   = null;
         cachedBestNodes = null;
+        cachedSVGString = null;
         return;
     }
     var m = $('input[name="r"]').filter(':checked').val();
@@ -163,6 +165,7 @@ function updateLattice() {
             } else {
                 outEl.innerHTML = data.svg || '';
             }
+            cachedSVGString = data.svg || null;
             var svgEl = outEl.querySelector('svg');
             if (svgEl) {
                 var wAttr = svgEl.getAttribute('width')  || '';
@@ -199,6 +202,62 @@ function updateLattice() {
     }, 'json');
 }
 
+function toggleDownloadMenu(event) {
+    event.stopPropagation();
+    var menu = document.getElementById('download-menu');
+    menu.classList.toggle('open');
+}
+
+function closeDownloadMenu() {
+    var menu = document.getElementById('download-menu');
+    if (menu) menu.classList.remove('open');
+}
+
+function downloadAs(format) {
+    closeDownloadMenu();
+    if (!cachedSVGString) return;
+
+    var inp = document.getElementById('inp').value.trim();
+    var base = inp
+        ? inp.replace(/[^0-9A-Za-z\u3040-\u9FFF]/g, '_').slice(0, 50)
+        : 'lattice';
+
+    if (format === 'svg') {
+        var blob = new Blob([cachedSVGString], {type: 'image/svg+xml'});
+        var url = URL.createObjectURL(blob);
+        var a = document.createElement('a');
+        a.href = url;
+        a.download = base + '.svg';
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+    } else if (format === 'png') {
+        var w = svgOrigPx ? svgOrigPx.width  : 800;
+        var h = svgOrigPx ? svgOrigPx.height : 600;
+        var scale = 2;
+        var blob2 = new Blob([cachedSVGString], {type: 'image/svg+xml'});
+        var url2 = URL.createObjectURL(blob2);
+        var img = new Image();
+        img.onload = function() {
+            var canvas = document.createElement('canvas');
+            canvas.width  = w * scale;
+            canvas.height = h * scale;
+            var ctx = canvas.getContext('2d');
+            ctx.scale(scale, scale);
+            ctx.drawImage(img, 0, 0, w, h);
+            URL.revokeObjectURL(url2);
+            var a2 = document.createElement('a');
+            a2.href = canvas.toDataURL('image/png');
+            a2.download = base + '.png';
+            document.body.appendChild(a2);
+            a2.click();
+            document.body.removeChild(a2);
+        };
+        img.src = url2;
+    }
+}
+
 var latticeTimer = null;
 function scheduleLattice() {
     if (latticeTimer !== null) {
@@ -216,4 +275,8 @@ $('input[name="r"]:radio').change(function() {
     var o = {"sentence": s, "mode": m};
     $.post('./tokenize', JSON.stringify(o), cb, 'json');
     updateLattice();
+});
+
+document.addEventListener('click', function() {
+    closeDownloadMenu();
 });

--- a/cmd/server/asset/demo.js
+++ b/cmd/server/asset/demo.js
@@ -135,6 +135,15 @@ document.getElementById('lattice-output').addEventListener('wheel', function(e) 
 
 function updateLattice() {
     var s = document.getElementById("inp").value;
+    if (s.trim() === '') {
+        document.getElementById('lattice-error').textContent = '';
+        document.getElementById('lattice-output').innerHTML = '';
+        document.getElementById('lattice-controls').style.display = 'none';
+        svgOrigDims = null;
+        svgOrigPx   = null;
+        cachedBestNodes = null;
+        return;
+    }
     var m = $('input[name="r"]').filter(':checked').val();
     $.post('./lattice', {s: s, r: m}, function(data) {
         var errEl = document.getElementById('lattice-error');

--- a/cmd/server/asset/graph.html
+++ b/cmd/server/asset/graph.html
@@ -44,13 +44,13 @@
   </table>
 
   <table class="tbl">
-    <thread><tr>
+    <thead><tr>
       <th>Surface</th>
       <th>Part-of-Speech</th>
       <th>Base Form</th>
       <th>Reading</th>
       <th>Pronunciation</th>
-    </tr></thread>
+    </tr></thead>
     <tbody id="morphs">
     {{range .Tokens}}
     <tr>

--- a/cmd/server/asset/graph.html
+++ b/cmd/server/asset/graph.html
@@ -68,7 +68,19 @@
     <strong>{{.CmdErr}}</strong>
     {{end}}
     {{if .GraphSVG}}
-    {{.GraphSVG}}
+    <div id="graph-svg-data" hidden data-svg="{{.GraphSVG}}"></div>
+    <div id="graph-output"></div>
+    <script>
+      (function() {
+        var svgStr = document.getElementById('graph-svg-data').dataset.svg;
+        var target = document.getElementById('graph-output');
+        if (typeof target.setHTML === 'function') {
+          target.setHTML(svgStr);
+        } else {
+          target.innerHTML = svgStr;
+        }
+      })();
+    </script>
     {{end}}
   </div>
 </div>

--- a/cmd/server/cmd.go
+++ b/cmd/server/cmd.go
@@ -5,10 +5,12 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"io/fs"
 	"log"
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -20,6 +22,20 @@ import (
 
 // Stderr is the standard error writer.
 var Stderr io.Writer = os.Stderr
+
+// staticFS is an http.FileSystem that serves only non-HTML files and
+// denies directory listings. It is used to expose /asset/ without leaking
+// server-side template sources (demo.html, graph.html).
+type staticFS struct {
+	base http.FileSystem
+}
+
+func (s staticFS) Open(name string) (http.File, error) {
+	if strings.HasSuffix(name, ".html") {
+		return nil, fs.ErrNotExist
+	}
+	return s.base.Open(name)
+}
 
 // subcommand property
 var (
@@ -103,7 +119,7 @@ func command(ctx context.Context, opt *option) error {
 	}
 
 	mux := http.NewServeMux()
-	mux.Handle("/asset/", http.FileServer(http.FS(assetFS)))
+	mux.Handle("/asset/", http.FileServer(staticFS{http.FS(assetFS)}))
 	mux.Handle("/", &TokenizeDemoHandler{tokenizer: t})
 	mux.Handle("/tokenize", &TokenizeHandler{tokenizer: t})
 	mux.Handle("/lattice", &LatticeHandler{tokenizer: t})

--- a/cmd/server/cmd.go
+++ b/cmd/server/cmd.go
@@ -103,8 +103,10 @@ func command(ctx context.Context, opt *option) error {
 	}
 
 	mux := http.NewServeMux()
+	mux.Handle("/asset/", http.FileServer(http.FS(assetFS)))
 	mux.Handle("/", &TokenizeDemoHandler{tokenizer: t})
 	mux.Handle("/tokenize", &TokenizeHandler{tokenizer: t})
+	mux.Handle("/lattice", &LatticeHandler{tokenizer: t})
 	srv := http.Server{
 		Addr:              opt.http,
 		Handler:           mux,

--- a/cmd/server/demo.go
+++ b/cmd/server/demo.go
@@ -22,20 +22,17 @@ var assetFS embed.FS
 
 // assets
 var (
-	graphT *template.Template
-	demoT  *template.Template
+	graphT = mustParseTemplate("graph", "asset/graph.html")
+	demoT  = mustParseTemplate("demo", "asset/demo.html")
 )
 
-func init() {
-	readAsset := func(path string) string {
-		b, err := assetFS.ReadFile(path)
-		if err != nil {
-			panic(err)
-		}
-		return string(b)
+func mustParseTemplate(name, path string) *template.Template {
+	b, err := assetFS.ReadFile(path)
+	if err != nil {
+		panic(err)
 	}
-	graphT = template.Must(template.New("graph").Parse(readAsset("asset/graph.html")))
-	demoT = template.Must(template.New("demo").Parse(readAsset("asset/demo.html")))
+
+	return template.Must(template.New(name).Parse(string(b)))
 }
 
 const (
@@ -137,10 +134,12 @@ func (h *LatticeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	sen := r.FormValue("s")
 	mode := r.FormValue("r")
 	m := tokenizer.Normal
+
 	switch mode {
 	case "Search", "Extended":
 		m = tokenizer.Search
 	}
+
 	var resp latticeResponse
 	_, svg, err := analyzeGraph(r.Context(), h.tokenizer, sen, m)
 	if err != nil {
@@ -148,7 +147,10 @@ func (h *LatticeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	} else {
 		resp.SVG = svg
 	}
-	_ = json.NewEncoder(w).Encode(resp)
+
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
 }
 
 // ServeHTTP serves a tokenize demo server.

--- a/cmd/server/demo.go
+++ b/cmd/server/demo.go
@@ -3,7 +3,8 @@ package server
 import (
 	"bytes"
 	"context"
-	_ "embed"
+	"embed"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"html/template"
@@ -16,16 +17,26 @@ import (
 	"github.com/ikawaha/kagome/v2/tokenizer"
 )
 
+//go:embed asset
+var assetFS embed.FS
+
 // assets
 var (
-	//go:embed asset/graph.html
-	graphHTML string
-	graphT    = template.Must(template.New("graph").Parse(graphHTML))
-
-	//go:embed asset/demo.html
-	demoHTML string
-	demoT    = template.Must(template.New("demo").Parse(demoHTML))
+	graphT *template.Template
+	demoT  *template.Template
 )
+
+func init() {
+	readAsset := func(path string) string {
+		b, err := assetFS.ReadFile(path)
+		if err != nil {
+			panic(err)
+		}
+		return string(b)
+	}
+	graphT = template.Must(template.New("graph").Parse(readAsset("asset/graph.html")))
+	demoT = template.Must(template.New("demo").Parse(readAsset("asset/demo.html")))
+}
 
 const (
 	graphvizCmd = "dot"
@@ -80,7 +91,7 @@ func toRecords(tokens []tokenizer.Token) []record {
 }
 
 //nolint:nonamedreturns
-func (h *TokenizeDemoHandler) analyzeGraph(ctx context.Context, sen string, mode tokenizer.TokenizeMode) (records []record, svg string, err error) {
+func analyzeGraph(ctx context.Context, tnz *tokenizer.Tokenizer, sen string, mode tokenizer.TokenizeMode) (records []record, svg string, err error) {
 	if _, err := exec.LookPath(graphvizCmd); err != nil {
 		return nil, "", errors.New("circo/graphviz is not installed in your $PATH")
 	}
@@ -95,7 +106,7 @@ func (h *TokenizeDemoHandler) analyzeGraph(ctx context.Context, sen string, mode
 	if err := cmd.Start(); err != nil {
 		return nil, "", fmt.Errorf("process done with error, %w", err)
 	}
-	tokens := h.tokenizer.AnalyzeGraph(w0, sen, mode)
+	tokens := tnz.AnalyzeGraph(w0, sen, mode)
 	if err := w0.Close(); err != nil {
 		return nil, "", fmt.Errorf("pipe close error, %w", err)
 	}
@@ -108,6 +119,36 @@ func (h *TokenizeDemoHandler) analyzeGraph(ctx context.Context, sen string, mode
 	}
 	records = toRecords(tokens)
 	return records, svg, nil
+}
+
+// LatticeHandler represents the lattice graph handler that returns SVG as JSON.
+type LatticeHandler struct {
+	tokenizer *tokenizer.Tokenizer
+}
+
+type latticeResponse struct {
+	SVG   string `json:"svg,omitempty"`
+	Error string `json:"error,omitempty"`
+}
+
+// ServeHTTP serves the lattice SVG as JSON.
+func (h *LatticeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	sen := r.FormValue("s")
+	mode := r.FormValue("r")
+	m := tokenizer.Normal
+	switch mode {
+	case "Search", "Extended":
+		m = tokenizer.Search
+	}
+	var resp latticeResponse
+	_, svg, err := analyzeGraph(r.Context(), h.tokenizer, sen, m)
+	if err != nil {
+		resp.Error = err.Error()
+	} else {
+		resp.SVG = svg
+	}
+	_ = json.NewEncoder(w).Encode(resp)
 }
 
 // ServeHTTP serves a tokenize demo server.
@@ -134,7 +175,7 @@ func (h *TokenizeDemoHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 		m = tokenizer.Search
 	}
 	var cmdErr string
-	records, svg, err := h.analyzeGraph(r.Context(), sen, m)
+	records, svg, err := analyzeGraph(r.Context(), h.tokenizer, sen, m)
 	if err != nil {
 		cmdErr = "Error: " + err.Error()
 		if errors.Is(err, context.DeadlineExceeded) {
@@ -145,13 +186,13 @@ func (h *TokenizeDemoHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 		Sentence string
 		Tokens   []record
 		CmdErr   string
-		GraphSVG template.HTML
+		GraphSVG string
 		Mode     string
 	}{
 		Sentence: sen,
 		Tokens:   records,
 		CmdErr:   cmdErr,
-		GraphSVG: template.HTML(svg), //nolint:gosec // G203: The used method does not auto-escape HTML. This can potentially lead to 'Cross-site Scripting' vulnerabilities, in case the attacker controls the input.
+		GraphSVG: svg,
 		Mode:     mode,
 	}); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/cmd/server/demo.go
+++ b/cmd/server/demo.go
@@ -132,6 +132,12 @@ type latticeResponse struct {
 func (h *LatticeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	sen := r.FormValue("s")
+	if strings.TrimSpace(sen) == "" {
+		if err := json.NewEncoder(w).Encode(latticeResponse{}); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+		return
+	}
 	mode := r.FormValue("r")
 	m := tokenizer.Normal
 

--- a/cmd/server/demo_test.go
+++ b/cmd/server/demo_test.go
@@ -54,7 +54,7 @@ func TestTokenizeDemoHandler_ServeHTTP(t *testing.T) {
 		if !bytes.Contains(body, []byte(`Kagome demo - Japanese morphological analyzer`)) {
 			t.Errorf("demo title not be found")
 		}
-		if bytes.Contains(body, []byte(`<svg width=`)) {
+		if bytes.Contains(body, []byte(`data-svg="`)) {
 			t.Errorf("unexpected svg found")
 		}
 	})
@@ -79,8 +79,8 @@ func TestTokenizeDemoHandler_ServeHTTP(t *testing.T) {
 		if !bytes.Contains(body, []byte(`Kagome demo - Japanese morphological analyzer`)) {
 			t.Errorf("demo title not be found")
 		}
-		if !bytes.Contains(body, []byte(`<svg width=`)) {
-			t.Errorf("svg not found")
+		if !bytes.Contains(body, []byte(`data-svg="&lt;svg width=`)) {
+			t.Errorf("svg not found in data-svg attribute")
 		}
 	})
 }
@@ -93,8 +93,7 @@ func TestTokenizeDemoHandler_analyzeGraph(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error, %v", err)
 	}
-	handler := TokenizeDemoHandler{tokenizer: tnz}
-	records, svg, err := handler.analyzeGraph(context.Background(), "ねこです", tokenizer.Normal)
+	records, svg, err := analyzeGraph(context.Background(), tnz, "ねこです", tokenizer.Normal)
 	if err != nil {
 		t.Fatalf("unexpected error, analyzeGraph() failed, %v", err)
 	}

--- a/cmd/server/demo_test.go
+++ b/cmd/server/demo_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -56,6 +57,10 @@ func TestTokenizeDemoHandler_ServeHTTP(t *testing.T) {
 		}
 		if bytes.Contains(body, []byte(`data-svg="`)) {
 			t.Errorf("unexpected svg found")
+		}
+		// radio button for the selected mode must have checked attribute
+		if !bytes.Contains(body, []byte(`value="Extended" checked`)) {
+			t.Errorf("Extended radio button not checked")
 		}
 	})
 
@@ -192,6 +197,85 @@ func Test_newRecord(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestLatticeHandler_ServeHTTP(t *testing.T) {
+	tnz, err := tokenizer.New(loadTestDict(t))
+	if err != nil {
+		t.Fatalf("unexpected error, %v", err)
+	}
+	t.Run("graphviz not installed", func(t *testing.T) {
+		if _, err := exec.LookPath(graphvizCmd); err == nil {
+			t.Skip("graphviz is installed, skipping error path test")
+		}
+		req := httptest.NewRequest(http.MethodPost, `/lattice?s=ねこ&r=Normal`, nil)
+		w := httptest.NewRecorder()
+		(&LatticeHandler{tokenizer: tnz}).ServeHTTP(w, req)
+		resp := w.Result()
+		defer resp.Body.Close() //nolint:errcheck
+
+		if got, want := resp.StatusCode, http.StatusOK; got != want {
+			t.Errorf("http status: got %d, want %d", got, want)
+		}
+		var body latticeResponse
+		if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+			t.Fatalf("json decode error, %v", err)
+		}
+		if body.Error == "" {
+			t.Errorf("expected error message, got empty")
+		}
+		if body.SVG != "" {
+			t.Errorf("expected empty SVG on error, got %q", body.SVG)
+		}
+	})
+	t.Run("success", func(t *testing.T) {
+		if _, err := exec.LookPath(graphvizCmd); err != nil {
+			t.Skipf("graphviz command not found, %v", err)
+		}
+		req := httptest.NewRequest(http.MethodPost, `/lattice?s=ねこです&r=Normal`, nil)
+		w := httptest.NewRecorder()
+		(&LatticeHandler{tokenizer: tnz}).ServeHTTP(w, req)
+		resp := w.Result()
+		defer resp.Body.Close() //nolint:errcheck
+
+		if got, want := resp.StatusCode, http.StatusOK; got != want {
+			t.Errorf("http status: got %d, want %d", got, want)
+		}
+		var body latticeResponse
+		if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+			t.Fatalf("json decode error, %v", err)
+		}
+		if body.Error != "" {
+			t.Errorf("unexpected error: %s", body.Error)
+		}
+		if !strings.HasPrefix(body.SVG, "<svg") {
+			t.Errorf("expected SVG content, got %q", body.SVG[:min(len(body.SVG), 50)])
+		}
+	})
+	t.Run("extended mode", func(t *testing.T) {
+		if _, err := exec.LookPath(graphvizCmd); err != nil {
+			t.Skipf("graphviz command not found, %v", err)
+		}
+		req := httptest.NewRequest(http.MethodPost, `/lattice?s=ねこです&r=Extended`, nil)
+		w := httptest.NewRecorder()
+		(&LatticeHandler{tokenizer: tnz}).ServeHTTP(w, req)
+		resp := w.Result()
+		defer resp.Body.Close() //nolint:errcheck
+
+		if got, want := resp.StatusCode, http.StatusOK; got != want {
+			t.Errorf("http status: got %d, want %d", got, want)
+		}
+		var body latticeResponse
+		if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+			t.Fatalf("json decode error, %v", err)
+		}
+		if body.Error != "" {
+			t.Errorf("unexpected error: %s", body.Error)
+		}
+		if !strings.HasPrefix(body.SVG, "<svg") {
+			t.Errorf("expected SVG content, got %q", body.SVG[:min(len(body.SVG), 50)])
+		}
+	})
 }
 
 func Test_toRecords(t *testing.T) {

--- a/cmd/server/demo_test.go
+++ b/cmd/server/demo_test.go
@@ -228,6 +228,27 @@ func TestLatticeHandler_ServeHTTP(t *testing.T) {
 			t.Errorf("expected empty SVG on error, got %q", body.SVG)
 		}
 	})
+	t.Run("empty input", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, `/lattice?s=&r=Normal`, nil)
+		w := httptest.NewRecorder()
+		(&LatticeHandler{tokenizer: tnz}).ServeHTTP(w, req)
+		resp := w.Result()
+		defer resp.Body.Close() //nolint:errcheck
+
+		if got, want := resp.StatusCode, http.StatusOK; got != want {
+			t.Errorf("http status: got %d, want %d", got, want)
+		}
+		var body latticeResponse
+		if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+			t.Fatalf("json decode error, %v", err)
+		}
+		if body.Error != "" {
+			t.Errorf("unexpected error: %s", body.Error)
+		}
+		if body.SVG != "" {
+			t.Errorf("expected empty SVG for empty input, got %q", body.SVG[:min(len(body.SVG), 50)])
+		}
+	})
 	for _, mode := range []string{"Normal", "Search", "Extended"} {
 		t.Run(mode, func(t *testing.T) {
 			if _, err := exec.LookPath(graphvizCmd); err != nil {

--- a/cmd/server/demo_test.go
+++ b/cmd/server/demo_test.go
@@ -228,54 +228,32 @@ func TestLatticeHandler_ServeHTTP(t *testing.T) {
 			t.Errorf("expected empty SVG on error, got %q", body.SVG)
 		}
 	})
-	t.Run("success", func(t *testing.T) {
-		if _, err := exec.LookPath(graphvizCmd); err != nil {
-			t.Skipf("graphviz command not found, %v", err)
-		}
-		req := httptest.NewRequest(http.MethodPost, `/lattice?s=ねこです&r=Normal`, nil)
-		w := httptest.NewRecorder()
-		(&LatticeHandler{tokenizer: tnz}).ServeHTTP(w, req)
-		resp := w.Result()
-		defer resp.Body.Close() //nolint:errcheck
+	for _, mode := range []string{"Normal", "Search", "Extended"} {
+		t.Run(mode, func(t *testing.T) {
+			if _, err := exec.LookPath(graphvizCmd); err != nil {
+				t.Skipf("graphviz command not found, %v", err)
+			}
+			req := httptest.NewRequest(http.MethodPost, `/lattice?s=ねこです&r=`+mode, nil)
+			w := httptest.NewRecorder()
+			(&LatticeHandler{tokenizer: tnz}).ServeHTTP(w, req)
+			resp := w.Result()
+			defer resp.Body.Close() //nolint:errcheck
 
-		if got, want := resp.StatusCode, http.StatusOK; got != want {
-			t.Errorf("http status: got %d, want %d", got, want)
-		}
-		var body latticeResponse
-		if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
-			t.Fatalf("json decode error, %v", err)
-		}
-		if body.Error != "" {
-			t.Errorf("unexpected error: %s", body.Error)
-		}
-		if !strings.HasPrefix(body.SVG, "<svg") {
-			t.Errorf("expected SVG content, got %q", body.SVG[:min(len(body.SVG), 50)])
-		}
-	})
-	t.Run("extended mode", func(t *testing.T) {
-		if _, err := exec.LookPath(graphvizCmd); err != nil {
-			t.Skipf("graphviz command not found, %v", err)
-		}
-		req := httptest.NewRequest(http.MethodPost, `/lattice?s=ねこです&r=Extended`, nil)
-		w := httptest.NewRecorder()
-		(&LatticeHandler{tokenizer: tnz}).ServeHTTP(w, req)
-		resp := w.Result()
-		defer resp.Body.Close() //nolint:errcheck
-
-		if got, want := resp.StatusCode, http.StatusOK; got != want {
-			t.Errorf("http status: got %d, want %d", got, want)
-		}
-		var body latticeResponse
-		if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
-			t.Fatalf("json decode error, %v", err)
-		}
-		if body.Error != "" {
-			t.Errorf("unexpected error: %s", body.Error)
-		}
-		if !strings.HasPrefix(body.SVG, "<svg") {
-			t.Errorf("expected SVG content, got %q", body.SVG[:min(len(body.SVG), 50)])
-		}
-	})
+			if got, want := resp.StatusCode, http.StatusOK; got != want {
+				t.Errorf("http status: got %d, want %d", got, want)
+			}
+			var body latticeResponse
+			if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+				t.Fatalf("json decode error, %v", err)
+			}
+			if body.Error != "" {
+				t.Errorf("unexpected error: %s", body.Error)
+			}
+			if !strings.HasPrefix(body.SVG, "<svg") {
+				t.Errorf("expected SVG content, got %q", body.SVG[:min(len(body.SVG), 50)])
+			}
+		})
+	}
 }
 
 func Test_toRecords(t *testing.T) {


### PR DESCRIPTION
- Add /lattice endpoint returning SVG as JSON
- Show morpheme table and lattice graph side-by-side in real time (previously lattice opened in a new tab via Lattice button)
- Highlight lattice node on morpheme row click
- Add zoom controls (＋/－, Fit, Reset, Ctrl+wheel) for SVG graph
- Auto-fit zoom to container on each analysis
- Split inline CSS/JS into asset/demo.css and asset/demo.js
- Embed assets via embed.FS; serve static files at /asset/

<img width="1400" height="786" alt="image" src="https://github.com/user-attachments/assets/534194c6-4ced-4cd9-9069-2ef779db5c37" />
